### PR TITLE
write catalog now writes relative paths per default

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -865,7 +865,10 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             if recursive:
                 append(self)
             write_catalog(
-                mappings, output=catalog_file, dir=dir, append=append_catalog
+                mappings,
+                output=catalog_file,
+                directory=dir,
+                append=append_catalog,
             )
 
     def get_imported_ontologies(self, recursive=False):

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -393,19 +393,16 @@ def write_catalog(
         output: name of catalog file.
         directory: directory path to the catalog file.  Only used if `output`
             is a relative path.
-        relative_paths: whether to write aboslute paths or paths relative to
-            directory for local paths inside the catalog file.
+        relative_paths: whether to write absolute or relative paths to
+            for file paths inside the catalog file.
         append: whether to append to a possible existing catalog file.
             If false, an existing file will be overwritten.
     """
     web_protocol = "http://", "https://", "ftp://"
     if relative_paths:
         for key, item in mappings.items():
-            mappings[key] = (
-                item
-                if item.startswith(web_protocol)
-                else os.path.relpath(item, Path(directory).resolve())
-            )
+            if not item.startswith(web_protocol):
+                mappings[key] = os.path.relpath(item, Path(directory).resolve())
     filename = (Path(directory) / output).resolve()
     if filename.exists() and append:
         iris = read_catalog(filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.19.5,<2
 openpyxl>=3.0.9,<3.1
 Owlready2>=0.28,!=0.32,!=0.34,<0.39
 packaging>=21.0<22
-pandas>=1.2,<1.5
+pandas>=1.2,<1.6
 Pygments>=2.7.4,<3
 pyparsing>=2.4.7
 PyYAML>=5.4.1,<7

--- a/tests/catalogs_for_testing/catalog-v001.xml
+++ b/tests/catalogs_for_testing/catalog-v001.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+        <uri name="http://emmo.info/testonto/0.1.0" uri="testonto.ttl"/>
+        <uri name="http://emmo.info/testonto/0.1.0/models" uri="models.ttl"/>
+    </group>
+</catalog>

--- a/tests/catalogs_for_testing/catalog-w-special-name.xml
+++ b/tests/catalogs_for_testing/catalog-w-special-name.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+        <uri name="http://emmo.info/testonto/0.1.0" uri="testonto.ttl"/>
+        <uri name="http://emmo.info/testonto/0.1.0/models" uri="models.ttl"/>
+    </group>
+</catalog>

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,19 +1,20 @@
 from typing import TYPE_CHECKING
+import defusedxml.ElementTree as ET
+from ontopy.utils import read_catalog, ReadCatalogError, write_catalog
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
 def test_catalog(repo_dir: "Path", tmpdir: "Path") -> None:
-    from ontopy.utils import read_catalog, ReadCatalogError, write_catalog
 
-    ontodir = repo_dir / "tests" / "testonto"
+    ontodir = repo_dir / "tests" / "catalogs_for_testing"
     catalog_expected = {
         "http://emmo.info/testonto/0.1.0": str(ontodir / "testonto.ttl"),
         "http://emmo.info/testonto/0.1.0/models": str(ontodir / "models.ttl"),
     }
 
-    catalog = read_catalog(str(ontodir / "catalog-v001.xml"))
+    catalog = read_catalog(str(ontodir / "catalog-w-special-name.xml"))
     assert catalog == catalog_expected
 
     catalog = read_catalog(str(ontodir))
@@ -25,6 +26,8 @@ def test_catalog(repo_dir: "Path", tmpdir: "Path") -> None:
     catalog, catalog_paths = read_catalog(str(ontodir), return_paths=True)
     assert catalog == catalog_expected
     assert catalog_paths == set([str(ontodir)])
+
+    write_catalog(catalog, output="cat.xml")
 
     catalog = read_catalog(
         "https://raw.githubusercontent.com/emmo-repo/EMMO/master/"
@@ -61,6 +64,66 @@ def test_catalog(repo_dir: "Path", tmpdir: "Path") -> None:
     assert "/abc/emmo.ttl" in catalog.values()
 
     tmp_catalog_path = tmpdir / "tmp-catalog.xml"
-    write_catalog(catalog, output=tmp_catalog_path)
+    write_catalog(catalog, output=tmp_catalog_path, relative_paths=False)
     tmp_catalog = read_catalog(str(tmp_catalog_path))
     assert tmp_catalog == catalog
+
+
+def test_write_catalog_choosing_relative_paths(
+    repo_dir: "Path", tmpdir: "Path"
+) -> None:
+    ontodir = repo_dir / "tests" / "catalogs_for_testing"
+    print(" PRINT ")
+    catalog1 = read_catalog(str(ontodir))
+    write_catalog(
+        catalog1,
+        output=(tmpdir / "cat-relative-paths.xml"),
+        relative_paths=True,
+    )
+    catalog2 = read_catalog(str(ontodir))
+    write_catalog(
+        catalog2,
+        output=(tmpdir / "cat-absolute-paths.xml"),
+        relative_paths=False,
+    )
+
+    catalog_w_absolute_paths_xml = ET.parse(tmpdir / "cat-absolute-paths.xml")
+    catalog_w_relative_paths_xml = ET.parse(tmpdir / "cat-relative-paths.xml")
+
+    catalog_w_absolute_paths_root = catalog_w_absolute_paths_xml.getroot()
+    catalog_w_relative_paths_root = catalog_w_relative_paths_xml.getroot()
+
+    absolutepaths = [
+        uri.attrib["uri"] for uri in catalog_w_absolute_paths_root[0]
+    ]
+    relativepaths = [
+        uri.attrib["uri"] for uri in catalog_w_relative_paths_root[0]
+    ]
+
+    ontodir = repo_dir / "tests" / "catalogs_for_testing"
+
+    catalog_expected_relative_paths = {
+        str("tests/catalogs_for_testing/testonto.ttl"),
+        str("tests/catalogs_for_testing/models.ttl"),
+    }
+
+    catalog_expected_absolute_paths = {
+        str(ontodir / "testonto.ttl"),
+        str(ontodir / "models.ttl"),
+    }
+
+    assert set(absolutepaths) == set(catalog_expected_absolute_paths)
+    assert set(relativepaths) == set(catalog_expected_relative_paths)
+
+    catalog3 = read_catalog(
+        "https://raw.githubusercontent.com/emmo-repo/EMMO/master/"
+        "catalog-v001.xml"
+    )
+    write_catalog(catalog3, output=(tmpdir / "cat-with-http-paths.xml"))
+
+    catalog_w_http_paths_xml = ET.parse(tmpdir / "cat-with-http-paths.xml")
+    catalog_w_http_paths_root = catalog_w_http_paths_xml.getroot()
+
+    paths = [uri.attrib["uri"] for uri in catalog_w_http_paths_root[0]]
+
+    assert set(catalog3.values()) == set(paths)


### PR DESCRIPTION
It is now possible to choose to write abslute paths when writing catalog, but relative paths to current folder are default.

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
