### PR TITLE
Corrected so that get_by_label_all also returns all concepts

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -343,13 +343,16 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         for key in annotations:
             entity = self.search_one(**{key: label})
             if entity:
+                print("entity from search one", entity)
                 return entity
 
         if self._special_labels and label in self._special_labels:
+            print("special_labels", self._special_labels[label])
             return self._special_labels[label]
 
         entity = self.world[self.base_iri + label]
         if entity:
+            print("from self.world", entity)
             return entity
 
         raise NoSuchLabelError(f"No label annotations matches {label!r}")
@@ -377,8 +380,14 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         entity = self.world.search(**{next(annotations): label})
         for key in annotations:
             entity.extend(self.world.search(**{key: label}))
+
         if self._special_labels and label in self._special_labels:
             entity.append(self._special_labels[label])
+
+        entity_only_in_world = self.world[self.base_iri + label]
+        if entity_only_in_world and entity_only_in_world not in entity:
+            entity.append(entity_only_in_world)
+
         if prefix:
             return [_ for _ in entity if _.namespace.ontology.prefix == prefix]
         return entity

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -381,9 +381,9 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         if self._special_labels and label in self._special_labels:
             entity.append(self._special_labels[label])
 
-        entity_only_in_world = self.world[self.base_iri + label]
-        if entity_only_in_world and entity_only_in_world not in entity:
-            entity.append(entity_only_in_world)
+        entity_accessed_directly = self.world[self.base_iri + label]
+        if entity_accessed_directly and entity_accessed_directly not in entity:
+            entity.append(entity_accessed_directly)
 
         if prefix:
             return [_ for _ in entity if _.namespace.ontology.prefix == prefix]

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -343,16 +343,13 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         for key in annotations:
             entity = self.search_one(**{key: label})
             if entity:
-                print("entity from search one", entity)
                 return entity
 
         if self._special_labels and label in self._special_labels:
-            print("special_labels", self._special_labels[label])
             return self._special_labels[label]
 
         entity = self.world[self.base_iri + label]
         if entity:
-            print("from self.world", entity)
             return entity
 
         raise NoSuchLabelError(f"No label annotations matches {label!r}")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,6 +18,14 @@ def test_basic(emmo: "Ontology") -> None:
     # Add entity directly
     onto.new_entity("Hydrogen", emmo.Atom)
 
+    # Test that new entity is found by both version of get_by_label
+    assert onto.get_by_label("Hydrogen") == onto.Hydrogen
+    assert onto.get_by_label_all("Hydrogen") == [onto.Hydrogen]
+
+    onto.sync_attributes()
+    # Test that after sync_attributes, the entity is not counted more than once
+    assert onto.get_by_label_all("Hydrogen") == [onto.Hydrogen]
+
     with pytest.raises(LabelDefinitionError):
         onto.new_entity("Hydr ogen", emmo.Atom)
 
@@ -40,8 +48,6 @@ def test_basic(emmo: "Ontology") -> None:
         water = H2O()
         water.hasSpatialDirectPart = [H1, H2, O]
 
-    print(onto.label_annotations)
-    print(onto._label_annotations)
     name_prefix = "myonto_"
     onto.sync_attributes(name_policy="sequential", name_prefix=name_prefix)
     assert f"{onto.base_iri}{name_prefix}0" in onto


### PR DESCRIPTION
# Description:
get_by_label_all did not return recently added entities before runnign sync_attributes.
This is now checked.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
