### PR TITLE
Catch TypeError if `is_instance_of` is not iterable

### DIFF
--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -391,9 +391,15 @@ class OntoDoc:
         # Instances (individuals)
         if hasattr(item, "instances"):
             points = []
-            for entity in [
-                _ for _ in item.instances() if item in _.is_instance_of
-            ]:
+            entities = []
+            for entity in item.instances():
+                try:
+                    if item in entity.is_instance_of:
+                        entities.append(entity)
+                except TypeError:
+                    # entity.is_instance_of is not an iterable
+                    pass
+            for entity in entities:
                 points.append(
                     point_style.format(
                         point=asstring(entity, link_style), ontology=onto


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #506 

See the issue for more information.

Unfortunately, I am not aware of how the `is_instance_of` property is generated or how to create a test ontology to create a test for this particular example that would trigger the bug prior to the current change.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
