### PR TITLE
Do not trigger an emmocheck failure for ontologies with a foaf:logo annotation

### DIFF
--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -82,6 +82,7 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
                 "core.prefLabel",
                 "core.altLabel",
                 "core.hiddenLabel",
+                "0.1.logo",  # foaf.logo
             )
         )
         exceptions.update(


### PR DESCRIPTION
CHAMIO (and EMMO with PR [212](https://github.com/emmo-repo/EMMO/pull/212)) includes a foaf:logo annotation.
This PR makes sure that this does not trigger a missing prefLabel error.

**Note** that the "automatic" prefix assigned by OwlReady2 for foaf is rather awkward. It becomes "0.1" since that is the last component of the foaf IRI: `http://xmlns.com/foaf/0.1/`. 


# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
