### PR TITLE
Added fix for adding annotations that are not strings in ontodoc

### DIFF
--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -288,7 +288,8 @@ class OntoDoc:
             annotations.keys(), key=lambda key: order.get(key, key)
         ):
             for value in annotations[key]:
-                if self.url_regex.match(value):
+                value = str(value)
+                if self.url_regex.match(str(value)):
                     doc.append(
                         annotation_style.format(
                             key=key, value=asstring(value, link_style)

--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -289,7 +289,7 @@ class OntoDoc:
         ):
             for value in annotations[key]:
                 value = str(value)
-                if self.url_regex.match(str(value)):
+                if self.url_regex.match(value):
                     doc.append(
                         annotation_style.format(
                             key=key, value=asstring(value, link_style)

--- a/tests/ontopy_tests/test_prefix.py
+++ b/tests/ontopy_tests/test_prefix.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 def test_prefix(testonto: "Ontology", emmo: "Ontology") -> None:
     """Test prefix in ontology"""
 
-    assert len(testonto.get_by_label_all("*")) == 2
+    assert len(testonto.get_by_label_all("*")) == 3
     assert testonto.get_by_label_all("*", prefix="testonto") == [
         testonto.TestClass
     ]

--- a/tests/testonto/models.ttl
+++ b/tests/testonto/models.ttl
@@ -18,4 +18,5 @@ skos:altLabel rdf:type owl:AnnotationProperty .
 
 :testclass rdf:type owl:Class ;
     rdfs:subClassOf owl:Thing ;
-    skos:prefLabel "TestClass"@en .
+    skos:prefLabel "TestClass"@en ;
+    skos:altLabel 25517 . # Test that values given as integers as still accepted by ontodoc

--- a/tests/testonto/models.ttl
+++ b/tests/testonto/models.ttl
@@ -19,4 +19,4 @@ skos:altLabel rdf:type owl:AnnotationProperty .
 :testclass rdf:type owl:Class ;
     rdfs:subClassOf owl:Thing ;
     skos:prefLabel "TestClass"@en ;
-    skos:altLabel 25517 . # Test that values given as integers as still accepted by ontodoc
+    skos:altLabel 25517 . # Test that values given as integers are accepted by ontodoc

--- a/tests/tools/test_ontodoc.py
+++ b/tests/tools/test_ontodoc.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.skip("ontodoc is tested in other ways")
 @pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
 def test_run(tool, tmpdir: Path) -> None:
     """Check that running `ontodoc` works."""
@@ -13,3 +12,6 @@ def test_run(tool, tmpdir: Path) -> None:
     )
 
     tool.main([str(test_file), str(tmpdir / "test.md")])
+    tool.main(
+        [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
+    )


### PR DESCRIPTION
Furthermore, reenabled test for ontodoc. This is still a minimal test, but I think it can be gradually expanded.

Lastly - because a new altLabel was added in the testontology, it was reveiled that the same entity is returned twice in get_by_label_all in test_prefix. Issue #511 was made bacause of this.

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
