### PR TITLE
Only generate new uuid if not already a valid one

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1113,6 +1113,8 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         should be updated.  Valid values are:
           None          not changed
           "uuid"        `name_prefix` followed by a global unique id (UUID).
+                        If the name is already valid accoridng to this standard
+                        it will not be regenerated.
           "sequential"  `name_prefix` followed a sequantial number.
         EMMO conventions imply ``name_policy=='uuid'``.
 
@@ -1170,6 +1172,8 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 try:
                     # Passing the following means that the name is valid
                     # and need not be regenerated.
+                    if not obj.name.startswith(name_prefix):
+                        raise ValueError
                     uuid.UUID(obj.name.lstrip(name_prefix), version=5)
                 except ValueError:
                     obj.name = name_prefix + str(

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1167,9 +1167,14 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         )
         if name_policy == "uuid":
             for obj in chain:
-                obj.name = name_prefix + str(
-                    uuid.uuid5(uuid.NAMESPACE_DNS, obj.name)
-                )
+                try:
+                    # Passing the following means that the name is valid
+                    # and need not be regenerated.
+                    uuid.UUID(obj.name.lstrip(name_prefix), version=5)
+                except ValueError:
+                    obj.name = name_prefix + str(
+                        uuid.uuid5(uuid.NAMESPACE_DNS, obj.name)
+                    )
         elif name_policy == "sequential":
             for obj in chain:
                 counter = 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -58,6 +58,9 @@ def test_basic(emmo: "Ontology") -> None:
     assert water.name.startswith("onto_")
     # A UUID is 32 chars long + 4 `-` chars = 36 chars
     assert len(water.name) == len(name_prefix) + 36
+    synced_uuid = water.name
+    onto.sync_attributes(name_policy="uuid", name_prefix=name_prefix)
+    assert synced_uuid == water.name
 
 
 def test_sync_reasoner(testonto: "Ontology") -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -62,6 +62,12 @@ def test_basic(emmo: "Ontology") -> None:
     onto.sync_attributes(name_policy="uuid", name_prefix=name_prefix)
     assert synced_uuid == water.name
 
+    water.name = water.name[1:]
+    assert water.name.startswith("nto_")
+    onto.sync_attributes(name_policy="uuid", name_prefix=name_prefix)
+    assert synced_uuid != water.name
+    assert water.name.startswith("onto_")
+
 
 def test_sync_reasoner(testonto: "Ontology") -> None:
     """Test `ontopy:Ontology.sync_reasoner()`."""


### PR DESCRIPTION
# Description:
When asking to sync_attributes with the uuid name_policy the name is regenerated for all, even if the alrealy have a valid name within this name_policy. This makes it impossible to add to an already existing ontology.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
