### PR TITLE
Add one-liner to remove 'azure' part of APT URLs

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -79,7 +79,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y graphviz openjdk-11-jre-headless
+      run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo apt-get update && sudo apt-get install -y graphviz openjdk-11-jre-headless
 
     - name: Install Python dependencies (and EMMOntoPy)
       run: |
@@ -125,6 +127,7 @@ jobs:
     - name: Check Ubuntu version we are running under
       run: |
         uname -a
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get update
 
     - name: Current environment


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #541 

Add the one-liner:

```shell
sudo sed -i 's/azure\.//' /etc/apt/sources.list
```

Prior to using `apt` in the relevant CI workflows and jobs.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix (sort of).
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
