### PR TITLE
Use SINTEF/ci-cd v2.1.0 in CI/CD workflows

### DIFF
--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.1.0
     if: github.repository == 'emmo-repo/EMMOntoPy' && startsWith(github.ref, 'refs/tags/v')
     with:
       git_username: EMMOntoPy Developers

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.1.0
     if: github.repository_owner == 'emmo-repo' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   updates-to-master:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.1.0
     if: github.repository_owner == 'emmo-repo'
     with:
       git_username: EMMOntoPy Developers

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.1.0
     if: github.repository_owner == 'emmo-repo'
     with:
       git_username: EMMOntoPy Developers

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.1.0
     with:
       # General
       install_extras: "[dev,docs]"


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #545 

The usage of v2.1.0 for the [SINTEF/ci-cd](https://sintef.github.io/ci-cd/2.1.0/) utility repository should result in prioritizing the usage of the supplied PAT secret, i.e., a custom personal access token instead of the generic `GITHUB_TOKEN`, which has some harsh rate-limits for GH API requests.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
