### PR TITLE
ontograph: colour updates, examples, bugfix

### DIFF
--- a/docs/tools-instructions.md
+++ b/docs/tools-instructions.md
@@ -197,12 +197,13 @@ optional arguments:
 
 ### Examples
 
-The figure below is generated with the following command:
 
 ```console
+ontograph --relations=all --legend --format=pdf emmo-inferred emmo.pdf # complete ontology
+ontograph --root=Holistic --relations=hasInput,hasOutput,hasTemporaryParticipant,hasAgent --parents=2 --legend --leaves=Measurement,Manufacturing,CompleteManufacturing,ManufacturedProduct,CommercialProduct,Manufacturer --format=png --exclude=Task,Workflow,Computation,MaterialTreatment emmo-inferred measurement.png
 ontograph --root=Material --relations=all --legend --format=png emmo-inferred material.png
 ```
-
+The figure below is generated with the last command in the list above.
 ![Graph generated with the ontograph tool.](images/material.png)
 
 ---

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -106,6 +106,9 @@ _default_style = {
         "hasSign": {"color": "orange"},
         "hasConvention": {"color": "orange", "style": "dashed"},
         "hasProperty": {"color": "orange", "style": "dotted"},
+        "hasOutput": {"color": "darkviolet", "style": "dotted"},
+        "hasInput": {"color": "darkviolet"},
+        "hasTemporaryParticipant": {"color": "darkviolet", "style": "dashed"},
     },
     "inverse": {"arrowhead": "inv"},
     "default_dataprop": {"color": "green", "constraint": "false"},
@@ -1092,7 +1095,7 @@ def cytoscapegraph(
             onto: ontology to be used for mouse actions.
             infobox: "left" or "right". Placement of infbox with
                      respect to graph.
-            force: force generate graph withour correct edgelabels.
+            force: force generate graph without correct edgelabels.
     Returns:
             cytoscapewidget with graph and infobox to be visualized
             in jupyter lab.

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -483,19 +483,25 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
             raise RuntimeError(f'`object` "{obj}" must have been added')
         key = (subject, predicate, obj)
         if key not in self.edges:
-            if edgelabel is None:
+            relations = self.style.get("relations", {})
+            rels = set(
+                self.ontology[_] for _ in relations if _ in self.ontology
+            )
+            if (edgelabel is None) and (
+                (predicate in rels) or (predicate == "isA")
+            ):
                 edgelabel = self.edgelabels
             label = None
             if edgelabel is None:
                 tokens = predicate.split()
                 if len(tokens) == 2 and tokens[1] in ("some", "only"):
-                    label = tokens[1]
+                    label = f"{tokens[0]} {tokens[1]}"
                 elif len(tokens) == 3 and tokens[1] in (
                     "exactly",
                     "min",
                     "max",
                 ):
-                    label = f"{tokens[1]} {tokens[2]}"
+                    label = f"{tokens[0]} {tokens[1]} {tokens[2]}"
             elif isinstance(edgelabel, str):
                 label = edgelabel
             elif isinstance(edgelabel, dict):

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -102,7 +102,7 @@ _default_style = {
         "hasSpatialDirectPart": {"color": "darkgreen", "style": "dashed"},
         "hasTemporalPart": {"color": "magenta"},
         "hasTemporalDirectPart": {"color": "magenta", "style": "dashed"},
-        "hasReferenceUnit": {"color": "darkgreen", "style": "dashed"},
+        "hasReferenceUnit": {"color": "cornflowerblue", "style": "dashed"},
         "hasSign": {"color": "orange"},
         "hasConvention": {"color": "orange", "style": "dashed"},
         "hasProperty": {"color": "orange", "style": "dotted"},
@@ -787,6 +787,10 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
 
         Hence, you usually want to call add_legend() as the last method
         before saving or displaying.
+
+        Relations with defined style will be bold in legend.
+        Relations that have inherited style from parent relation
+        will not be bold.
         """
         rels = self.style.get("relations", {})
         if relations is None:
@@ -806,9 +810,16 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
         label1 = [table]
         label2 = [table]
         for index, relation in enumerate(relations):
-            label1.append(
-                f'<tr><td align="right" port="i{index}">{relation}</td></tr>'
-            )
+            if relation in rels:
+                label1.append(
+                    f'<tr><td align="right" '
+                    f'port="i{index}"><b>{relation}</b></td></tr>'
+                )
+            else:
+                label1.append(
+                    f'<tr><td align="right" '
+                    f'port="i{index}">{relation}</td></tr>'
+                )
             label2.append(f'<tr><td port="i{index}">&nbsp;</td></tr>')
         label1.append("</table>>")
         label2.append("</table>>")

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -15,7 +15,7 @@ import graphviz
 
 from ontopy.utils import asstring, get_label
 from ontopy.ontology import Ontology
-from ontopy.utils import EMMOntoPyException
+from ontopy.utils import EMMOntoPyException, get_format
 
 if TYPE_CHECKING:
     from ipywidgets.widgets.widget_templates import GridspecLayout
@@ -209,7 +209,7 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
         Whether to add labels to the edges of the generated graph.
         It is also possible to provide a dict mapping the
         full labels (with cardinality stripped off for restrictions)
-        to some abbriviations.
+        to some abbreviations.
     addnodes : bool
         Whether to add missing target nodes in relations.
     addconstructs : bool
@@ -707,6 +707,10 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
             rels: relations to be considered that have default styles,
                 either for the prefLabel or one of the altLabels
         """
+        print("entity", entity)
+        print("relations", relations)
+        print("rels", rels)
+        print("entity.mro", list(entity.mro()))
         for relation in entity.mro():
             if relation in rels:
                 if get_label(relation) in relations:
@@ -868,9 +872,8 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
     def save(self, filename, fmt=None, **kwargs):
         """Saves graph to `filename`.  If format is not given, it is
         inferred from `filename`."""
-        base, ext = os.path.splitext(filename)
-        if fmt is None:
-            fmt = ext.lstrip(".")
+        base = os.path.splitext(filename)[0]
+        fmt = get_format(filename, default="svg", fmt=fmt)
         kwargs.setdefault("cleanup", True)
         if fmt in ("graphviz", "gv"):
             if "dictionary" in kwargs:

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -485,7 +485,6 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
         if key not in self.edges:
             if edgelabel is None:
                 edgelabel = self.edgelabels
-
             label = None
             if edgelabel is None:
                 tokens = predicate.split()
@@ -503,7 +502,6 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
                 label = edgelabel.get(predicate, predicate)
             elif edgelabel:
                 label = predicate
-
             kwargs = self.get_edge_attrs(predicate, attrs=attrs)
             self.dot.edge(subject, obj, label=label, **kwargs)
             self.edges.add(key)
@@ -707,10 +705,6 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
             rels: relations to be considered that have default styles,
                 either for the prefLabel or one of the altLabels
         """
-        print("entity", entity)
-        print("relations", relations)
-        print("rels", rels)
-        print("entity.mro", list(entity.mro()))
         for relation in entity.mro():
             if relation in rels:
                 if get_label(relation) in relations:

--- a/ontopy/graph.py
+++ b/ontopy/graph.py
@@ -810,7 +810,7 @@ class OntoGraph:  # pylint: disable=too-many-instance-attributes
         label1 = [table]
         label2 = [table]
         for index, relation in enumerate(relations):
-            if relation in rels:
+            if (relation in rels) or (relation == "isA"):
                 label1.append(
                     f'<tr><td align="right" '
                     f'port="i{index}"><b>{relation}</b></td></tr>'

--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import yaml
 import owlready2
 
-from ontopy.utils import asstring, camelsplit, get_label
+from ontopy.utils import asstring, camelsplit, get_label, get_format
 from ontopy.graph import OntoGraph, filter_classes
 
 if TYPE_CHECKING:
@@ -1177,7 +1177,7 @@ class DocPP:  # pylint: disable=too-many-instance-attributes
         for reg, sub in substitutions:
             content = re.sub(reg, sub, content)
 
-        fmt = get_format(outfile, fmt)
+        fmt = get_format(outfile, default="html", fmt=fmt)
         if fmt not in ("simple-html", "markdown", "md"):  # Run pandoc
             if not genfile:
                 with NamedTemporaryFile(mode="w+t", suffix=".md") as temp_file:
@@ -1408,17 +1408,6 @@ def run_pandoc_pdf(latex_dir, pdf_engine, outfile, args, verbose=True):
             print()
             print(f"move {pdffile} to {outfile}")
         shutil.move(pdffile, outfile)
-
-
-def get_format(outfile, fmt=None):
-    """Infer format from outfile and format."""
-    if fmt is None:
-        fmt = os.path.splitext(outfile)[1]
-    if not fmt:
-        fmt = "html"
-    if fmt.startswith("."):
-        fmt = fmt[1:]
-    return fmt
 
 
 def get_style(fmt):

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -724,3 +724,14 @@ def normalise_url(url):
     components = list(splitted)
     components[2] = os.path.normpath(splitted.path)
     return urllib.parse.urlunsplit(components)
+
+
+def get_format(outfile: str, default: str, fmt: str = None):
+    """Infer format from outfile and format."""
+    if fmt is None:
+        fmt = os.path.splitext(outfile)[1]
+    if not fmt:
+        fmt = default
+    if fmt.startswith("."):
+        fmt = fmt[1:]
+    return fmt

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -732,6 +732,4 @@ def get_format(outfile: str, default: str, fmt: str = None):
         fmt = os.path.splitext(outfile)[1]
     if not fmt:
         fmt = default
-    if fmt.startswith("."):
-        fmt = fmt[1:]
-    return fmt
+    return fmt.lstrip(".")

--- a/tests/ontopy_tests/test_graph.py
+++ b/tests/ontopy_tests/test_graph.py
@@ -77,7 +77,7 @@ def test_graph(testonto: "Ontology", tmpdir: "Path") -> None:
     graph.save(tmpdir / "testonto.png")
 
 
-def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
+def test_emmo_graphs(emmo: "Ontology", repo_dir: "Path") -> None:
     """Testing OntoGraph on various aspects of EMMO.
 
     Parameters:
@@ -86,144 +86,154 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
         tmpdir: A built in pytest fixture to get a function-scoped
             temporary directory'
     """
+    tmpdir = repo_dir
     import owlready2
     from ontopy.graph import OntoGraph
+    import warnings
 
-    graph = OntoGraph(
-        emmo,
-        emmo.hasPart,
-        leaves=("mereological", "semiotical", "causal"),
-    )
-    graph.save(tmpdir / "hasPart.svg")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        graph = OntoGraph(
+            emmo,
+            emmo.hasPart,
+            leaves=("mereological", "semiotical", "causal"),
+        )
+        graph.save(tmpdir / "hasPart.svg")
 
-    graph = OntoGraph(
-        emmo, emmo.Matter, relations="all", addnodes=True, edgelabels=None
-    )
-    graph.save(tmpdir / "Matter.png")
+        graph = OntoGraph(
+            emmo, emmo.Matter, relations="all", addnodes=True, edgelabels=None
+        )
+        graph.save(tmpdir / "Matter.png")
 
-    graph = OntoGraph(
-        emmo,
-        emmo.ElementaryParticle,
-        relations="all",
-        addnodes=True,
-        edgelabels=None,
-    )
-    graph.save(tmpdir / "ElementaryParticle.png")
+        graph = OntoGraph(
+            emmo,
+            emmo.ElementaryParticle,
+            relations="all",
+            addnodes=True,
+            edgelabels=None,
+        )
+        graph.save(tmpdir / "ElementaryParticle.png")
 
-    graph = OntoGraph(
-        emmo,
-        emmo.SIBaseUnit,
-        relations="all",
-        addnodes=True,
-        edgelabels=True,
-        addconstructs=False,
-        graph_attr={"rankdir": "RL"},
-    )
-    graph.add_legend()
-    graph.save(tmpdir / "SIBaseUnit.png")
+        graph = OntoGraph(
+            emmo,
+            emmo.SIBaseUnit,
+            relations="all",
+            addnodes=True,
+            edgelabels=True,
+            addconstructs=False,
+            graph_attr={"rankdir": "RL"},
+        )
+        graph.add_legend()
+        graph.save(tmpdir / "SIBaseUnit.png")
 
-    graph = OntoGraph(emmo, emmo.EMMORelation, relations="all", edgelabels=None)
-    graph.save(tmpdir / "EMMORelation.png")
+        graph = OntoGraph(
+            emmo, emmo.EMMORelation, relations="all", edgelabels=None
+        )
+        graph.save(tmpdir / "EMMORelation.png")
 
-    graph = OntoGraph(
-        emmo,
-        emmo.Quantity,
-        leaves=[emmo.DerivedQuantity, emmo.BaseQuantity, emmo.PhysicalConstant],
-        relations="all",
-        edgelabels=None,
-        addnodes=True,
-        addconstructs=True,
-        graph_attr={"rankdir": "RL"},
-    )
-    graph.add_legend()
-    graph.save(tmpdir / "Quantity.svg")
-
-    # Used for figures
-
-    graph = OntoGraph(emmo)
-    graph.add_legend("all")
-    graph.save(tmpdir / "legend.png")
-
-    graph = OntoGraph(
-        emmo, emmo.EMMO, leaves=[emmo.Perspective, emmo.Elementary]
-    )
-    graph.save(tmpdir / "top.png")
-
-    leaves = set()
-    for s in emmo.Perspective.subclasses():
-        leaves.update(s.subclasses())
-    graph = OntoGraph(emmo, emmo.Perspective, leaves=leaves, parents=1)
-    graph.save(tmpdir / "Perspectives.png")
-
-    leaves = {
-        emmo.Interpreter,
-        emmo.Conventional,
-        emmo.Icon,
-        emmo.Observation,
-        emmo.Object,
-    }
-    hidden = {
-        emmo.SIUnitSymbol,
-        emmo.SpecialUnit,
-        emmo.Manufacturing,
-        emmo.Engineered,
-        emmo.PhysicalPhenomenon,
-    }
-    semiotic = emmo.get_branch(emmo.Holistic, leaves=leaves.union(hidden))
-    semiotic.difference_update(hidden)
-    graph = OntoGraph(emmo)
-    graph.add_entities(semiotic, relations="all", edgelabels=False)
-    graph.save(tmpdir / "Semiotic.png")
-    graph.add_legend()
-    graph.save(tmpdir / "Semiotic+legend.png")
-
-    legend = OntoGraph(emmo)
-    legend.add_legend(graph.get_relations())
-    legend.save(tmpdir / "Semiotic-legend.png")
-
-    # Measurement
-    leaves = {emmo.Object}
-
-    hidden = {
-        emmo.SIUnitSymbol,
-        emmo.SpecialUnit,
-        emmo.Manufacturing,
-        emmo.Engineered,
-        emmo.PhysicalPhenomenon,
-        emmo.Icon,
-        emmo.Interpretant,
-        emmo.Index,
-        emmo.Subjective,
-        emmo.NominalProperty,
-        emmo.ConventionalQuantitativeProperty,
-        emmo.ModelledQuantitativeProperty,
-        emmo.Theorization,
-        emmo.Experiment,
-        emmo.Theory,
-        emmo.Variable,
-    }
-    semiotic = emmo.get_branch(emmo.Holistic, leaves=leaves.union(hidden))
-    semiotic.difference_update(hidden)
-    graph = OntoGraph(emmo)
-    graph.add_entities(semiotic, relations="all", edgelabels=False)
-    graph.add_legend()
-    graph.save(tmpdir / "measurement.png")
-
-    # Reductionistic perspective
-    graph = OntoGraph(
-        emmo,
-        emmo.Reductionistic,
-        relations="all",
-        addnodes=False,
-        leaves=[
+        graph = OntoGraph(
+            emmo,
             emmo.Quantity,
-            emmo.String,
-            emmo.PrefixedUnit,
-            emmo.SymbolicConstruct,
-            emmo.Matter,
-        ],
-        parents=2,
-        edgelabels=None,
-    )
-    graph.add_legend()
-    graph.save(tmpdir / "Reductionistic.png")
+            leaves=[
+                emmo.DerivedQuantity,
+                emmo.BaseQuantity,
+                emmo.PhysicalConstant,
+            ],
+            relations="all",
+            edgelabels=None,
+            addnodes=True,
+            addconstructs=True,
+            graph_attr={"rankdir": "RL"},
+        )
+        graph.add_legend()
+        graph.save(tmpdir / "Quantity.svg")
+
+        # Used for figures
+
+        graph = OntoGraph(emmo)
+        graph.add_legend("all")
+        graph.save(tmpdir / "legend.png")
+
+        graph = OntoGraph(
+            emmo, emmo.EMMO, leaves=[emmo.Perspective, emmo.Elementary]
+        )
+        graph.save(tmpdir / "top.png")
+
+        leaves = set()
+        for s in emmo.Perspective.subclasses():
+            leaves.update(s.subclasses())
+        graph = OntoGraph(emmo, emmo.Perspective, leaves=leaves, parents=1)
+        graph.save(tmpdir / "Perspectives.png")
+
+        leaves = {
+            emmo.Interpreter,
+            emmo.Conventional,
+            emmo.Icon,
+            emmo.Observation,
+            emmo.Object,
+        }
+        hidden = {
+            emmo.SIUnitSymbol,
+            emmo.SpecialUnit,
+            emmo.Manufacturing,
+            emmo.Engineered,
+            emmo.PhysicalPhenomenon,
+        }
+        semiotic = emmo.get_branch(emmo.Holistic, leaves=leaves.union(hidden))
+        semiotic.difference_update(hidden)
+        graph = OntoGraph(emmo)
+        graph.add_entities(semiotic, relations="all", edgelabels=False)
+        graph.save(tmpdir / "Semiotic.png")
+        graph.add_legend()
+        graph.save(tmpdir / "Semiotic+legend.png")
+
+        legend = OntoGraph(emmo)
+        legend.add_legend(graph.get_relations())
+        legend.save(tmpdir / "Semiotic-legend.png")
+
+        # Measurement
+        leaves = {emmo.Object}
+
+        hidden = {
+            emmo.SIUnitSymbol,
+            emmo.SpecialUnit,
+            emmo.Manufacturing,
+            emmo.Engineered,
+            emmo.PhysicalPhenomenon,
+            emmo.Icon,
+            emmo.Interpretant,
+            emmo.Index,
+            emmo.Subjective,
+            emmo.NominalProperty,
+            emmo.ConventionalQuantitativeProperty,
+            emmo.ModelledQuantitativeProperty,
+            emmo.Theorization,
+            emmo.Experiment,
+            emmo.Theory,
+            emmo.Variable,
+        }
+        semiotic = emmo.get_branch(emmo.Holistic, leaves=leaves.union(hidden))
+        semiotic.difference_update(hidden)
+        graph = OntoGraph(emmo)
+        graph.add_entities(semiotic, relations="all", edgelabels=False)
+        graph.add_legend()
+        graph.save(tmpdir / "measurement.png")
+
+        # Reductionistic perspective
+        graph = OntoGraph(
+            emmo,
+            emmo.Reductionistic,
+            relations="all",
+            addnodes=False,
+            leaves=[
+                emmo.Quantity,
+                emmo.String,
+                emmo.PrefixedUnit,
+                emmo.SymbolicConstruct,
+                emmo.Matter,
+            ],
+            parents=2,
+            edgelabels=None,
+        )
+        graph.add_legend()
+        graph.save(tmpdir / "Reductionistic.png")

--- a/tests/ontopy_tests/test_graph.py
+++ b/tests/ontopy_tests/test_graph.py
@@ -87,7 +87,8 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
             temporary directory'
     """
     import owlready2
-    from ontopy.graph import OntoGraph
+    from ontopy.graph import OntoGraph, plot_modules
+    from ontopy import get_ontology
     import warnings
 
     with warnings.catch_warnings():
@@ -118,7 +119,7 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
             emmo.SIBaseUnit,
             relations="all",
             addnodes=True,
-            edgelabels=True,
+            edgelabels=False,
             addconstructs=False,
             graph_attr={"rankdir": "RL"},
         )
@@ -139,7 +140,7 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
                 emmo.PhysicalConstant,
             ],
             relations="all",
-            edgelabels=None,
+            edgelabels=True,
             addnodes=True,
             addconstructs=True,
             graph_attr={"rankdir": "RL"},
@@ -181,7 +182,7 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
         semiotic = emmo.get_branch(emmo.Holistic, leaves=leaves.union(hidden))
         semiotic.difference_update(hidden)
         graph = OntoGraph(emmo)
-        graph.add_entities(semiotic, relations="all", edgelabels=False)
+        graph.add_entities(semiotic, relations="all", edgelabels=None)
         graph.save(tmpdir / "Semiotic.png")
         graph.add_legend()
         graph.save(tmpdir / "Semiotic+legend.png")
@@ -235,4 +236,11 @@ def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
             edgelabels=None,
         )
         graph.add_legend()
-        graph.save(tmpdir / "Reductionistic.png")
+        graph.save(tmpdir / "Reductionistic.png", fmt="graphviz")
+
+        # View modules
+
+        onto = get_ontology(
+            "https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta4/emmo.ttl"
+        ).load()
+        plot_modules(onto, tmpdir / "modules.png", ignore_redundant=True)

--- a/tests/ontopy_tests/test_graph.py
+++ b/tests/ontopy_tests/test_graph.py
@@ -77,7 +77,7 @@ def test_graph(testonto: "Ontology", tmpdir: "Path") -> None:
     graph.save(tmpdir / "testonto.png")
 
 
-def test_emmo_graphs(emmo: "Ontology", repo_dir: "Path") -> None:
+def test_emmo_graphs(emmo: "Ontology", tmpdir: "Path") -> None:
     """Testing OntoGraph on various aspects of EMMO.
 
     Parameters:
@@ -86,7 +86,6 @@ def test_emmo_graphs(emmo: "Ontology", repo_dir: "Path") -> None:
         tmpdir: A built in pytest fixture to get a function-scoped
             temporary directory'
     """
-    tmpdir = repo_dir
     import owlready2
     from ontopy.graph import OntoGraph
     import warnings

--- a/tools/ontodoc
+++ b/tools/ontodoc
@@ -16,12 +16,12 @@ if rootdir not in sys.path:
 from ontopy import World, onto_path  # pylint: disable=import-error
 from ontopy.ontodoc import (  # pylint: disable=import-error
     OntoDoc,
-    get_format,
     get_style,
     get_figformat,
     get_maxwidth,
     get_docpp,
 )
+from ontopy.utils import get_format
 
 import owlready2
 
@@ -231,7 +231,7 @@ def main(argv: list = None):
         onto.sync_reasoner(reasoner=args.reasoner)
 
     # Instantiate ontodoc instance
-    fmt = get_format(args.outfile, args.format)
+    fmt = get_format(args.outfile, default="html", fmt=args.format)
     style = get_style(fmt)
     figformat = args.figformat if args.figformat else get_figformat(fmt)
     maxwidth = args.max_figwidth if args.max_figwidth else get_maxwidth(fmt)

--- a/tools/ontograph
+++ b/tools/ontograph
@@ -19,7 +19,7 @@ from ontopy.graph import (  # pylint: disable=import-error
     plot_modules,
     _default_style,
 )
-from ontopy.utils import get_label  # pylint: disable=import-error
+from ontopy.utils import get_label, get_format  # pylint: disable=import-error
 import warnings
 import owlready2
 
@@ -327,13 +327,15 @@ def main(
             graph.add_legend()
 
         # Plot and display
+        fmt = get_format(args.output, default="svg", fmt=args.format)
+
         if args.output:
             if len(roots) > 1:
                 head, tail = args.output.rsplit(".", maxsplit=1)
                 output = ".".join((head, get_label(root), tail))
             else:
                 output = args.output
-            graph.save(output, format=args.format)
+            graph.save(output, fmt=fmt)
 
         if not args.output or args.display:
             graph.view()

--- a/tools/ontograph
+++ b/tools/ontograph
@@ -160,6 +160,7 @@ def main(
         "--edgelabels",
         "-e",
         action="store_true",
+        default=None,
         help="Whether to add labels to edges.",
     )
     parser.add_argument(

--- a/tools/ontograph
+++ b/tools/ontograph
@@ -321,7 +321,7 @@ def main(
             addconstructs=args.addconstructs,
         )
         if args.parents:
-            graph.add_parents(args.parents)
+            graph.add_parents(root, levels=args.parents)
 
         if args.legend:
             graph.add_legend()


### PR DESCRIPTION
# Description:
* Updated colours so that all object properties currently in use in EMMO get a default colour (many as subproperties of a  property with default colour).

* The parents option in ontograph had a bug that is fixed.

* Added also som examples for ontograph.

* Updated pytest on writing emmographs to fail on warnings, in order to pick up if graph generation of EMMO suddensly starts haveing issues.

* Documentation stated that ontograph would guess format from file extension. This was not implemented, so moved the guess_format from ontodoc to utils and made use of it in ontograph.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [x] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
