### PR TITLE
Added two additional exceptions to emmocheck

### DIFF
--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -120,7 +120,6 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
                 "2-manifold",
                 "3-manifold",
                 "C++",
-                "3DPrinting",
             )
         )
         exceptions.update(self.get_config("test_class_label.exceptions", ()))

--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -82,6 +82,7 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
                 "core.prefLabel",
                 "core.altLabel",
                 "core.hiddenLabel",
+                "foaf.logo",
                 "0.1.logo",  # foaf.logo
             )
         )
@@ -119,6 +120,7 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
                 "2-manifold",
                 "3-manifold",
                 "C++",
+                "3DPrinting",
             )
         )
         exceptions.update(self.get_config("test_class_label.exceptions", ()))


### PR DESCRIPTION
# Description:
Added the following two exceptions to emmocheck
- foaf.logo comes from foaf and does not have a prefLabel
- Accept 3DPrinting in the DOAM ontology as a valid prefLabel, even though it does not start with a letter


## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
