### PR TITLE
Updated get_by_label() so that it now accepts label, name and full iri

### DIFF
--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -21,6 +21,7 @@ import ontopy
 from ontopy import get_ontology
 from ontopy.utils import EMMOntoPyException, NoSuchLabelError
 from ontopy.utils import ReadCatalogError, read_catalog
+from ontopy.ontology import LabelDefinitionError
 from ontopy.manchester import evaluate
 import owlready2  # pylint: disable=C0411
 
@@ -276,7 +277,12 @@ def create_ontology_from_pandas(  # pylint:disable=too-many-locals,too-many-bran
                 if not parents:
                     parents = [owlready2.Thing]
 
-                concept = onto.new_entity(name, parents)
+                try:
+                    concept = onto.new_entity(name, parents)
+                except LabelDefinitionError:
+                    concepts_with_errors["wrongly_defined"].append(name)
+                    continue
+
                 added_rows.add(index)
                 # Add elucidation
                 try:

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -187,10 +187,10 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
     )
 
     # Other settings
-    _colon_in_name = False
-    colon_in_name = property(
-        fget=lambda self: self._colon_in_name,
-        fset=lambda self, v: setattr(self, "_colon_in_name", bool(v)),
+    _colon_in_label = False
+    colon_in_label = property(
+        fget=lambda self: self._colon_in_label,
+        fset=lambda self, v: setattr(self, "_colon_in_label", bool(v)),
         doc="Whether to accept colon in name-part of IRI.  "
         "If true, the name cannot be prefixed.",
     )
@@ -270,7 +270,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         label_annotations: str = None,
         prefix: str = None,
         imported: bool = True,
-        colon_in_name: bool = None,
+        colon_in_label: bool = None,
     ):
         """Returns entity with label annotation `label`.
 
@@ -286,9 +286,9 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                (#) stripped off).  The search for a matching label will be
                limited to this namespace.
            imported: Whether to also look for `label` in imported ontologies.
-           colon_in_name: Whether to accept colon (:) in name-part of IRI.
-               Defaults to the `colon_in_name` property of `self`.
-               A true value cannot be combined with `prefix`.
+           colon_in_label: Whether to accept colon (:) in a label or name-part
+               of IRI.  Defaults to the `colon_in_label` property of `self`.
+               Setting this true cannot be combined with `prefix`.
 
         If several entities have the same label, only the one which is
         found first is returned.Use get_by_label_all() to get all matches.
@@ -312,12 +312,12 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 except ValueError:
                     pass
 
-        if colon_in_name is None:
-            colon_in_name = self._colon_in_name
-        if colon_in_name:
+        if colon_in_label is None:
+            colon_in_label = self._colon_in_label
+        if colon_in_label:
             if prefix:
                 raise ValueError(
-                    "`prefix` cannot be combined with `colon_in_name`"
+                    "`prefix` cannot be combined with `colon_in_label`"
                 )
         else:
             splitlabel = label.split(":", 1)

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -197,7 +197,6 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             dirset.update(_.label.first() for _ in lst if hasattr(_, "label"))
         if self._dir_name:
             dirset.update(_.name for _ in lst if hasattr(_, "name"))
-
         dirset.difference_update({None})  # get rid of possible None
         return sorted(dirset)
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -276,12 +276,17 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         If several entities have the same label, only the one which is
         found first is returned.Use get_by_label_all() to get all matches.
 
+        Note, if different prefixes are provided in the label and via
+        the `prefix` argument a warning will be issued and the
+        `prefix` argument will take precedence.
+
         A NoSuchLabelError is raised if `label` cannot be found.
 
         Note
         ----
         The current implementation also supports "*" as a wildcard
         matching any number of characters. This may change in the future.
+
         """
         # pylint: disable=too-many-arguments,too-many-branches,invalid-name
         if not isinstance(label, str):
@@ -308,9 +313,6 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 except ValueError:
                     pass
 
-        # Comment to reviewer:
-        # Since providing the prefix as argument is more explicit, I think
-        # that should take precedence.  Changed it below...
         splitlabel = label.split(":", 1)
         if len(splitlabel) == 2 and not splitlabel[1].startswith("//"):
             label = splitlabel[1]

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -280,29 +280,11 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         `prefix` argument will take precedence.
 
         A NoSuchLabelError is raised if `label` cannot be found.
-
-        Note
-        ----
-        The current implementation also supports "*" as a wildcard
-        matching any number of characters. This may change in the future.
-
         """
         # pylint: disable=too-many-arguments,too-many-branches,invalid-name
         if not isinstance(label, str):
             raise TypeError(
                 f"Invalid label definition, must be a string: {label!r}"
-            )
-
-        # Comment to reviewer:
-        # Do we really want to disallow space in label?
-        # I think we wanted ontopy to work with any ontology, also ontologies
-        # having space in their labels.
-        # Rather than enforcing EMMO conventions here, I think the user should
-        # run emmocheck on the ontology - it will alert about labels with
-        # spaces
-        if " " in label:
-            raise ValueError(
-                f"Invalid label definition, {label!r} contains spaces."
             )
 
         if self._label_annotations is None:
@@ -382,6 +364,11 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         """Like get_by_label(), but returns a list with all matching labels.
 
         Returns an empty list if no matches could be found.
+
+        Note
+        ----
+        The current implementation also supports "*" as a wildcard
+        matching any number of characters. This may change in the future.
         """
         if not isinstance(label, str):
             raise TypeError(

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -353,9 +353,9 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
 
         # First entity with matching label annotation
         annotation_ids = (
-            (self._abbreviate(a, False) for a in label_annotations)
+            (self._abbreviate(ann, False) for ann in label_annotations)
             if label_annotations
-            else (a.storid for a in self.label_annotations)
+            else (ann.storid for ann in self.label_annotations)
         )
         get_triples = (
             self.world._get_data_triples_spod_spod

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -187,19 +187,19 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
     )
 
     def __dir__(self):
-        set_dir = set(super().__dir__())
+        dirset = set(super().__dir__())
         lst = list(self.get_entities(imported=self._dir_imported))
         if self._dir_preflabel:
-            set_dir.update(
+            dirset.update(
                 _.prefLabel.first() for _ in lst if hasattr(_, "prefLabel")
             )
         if self._dir_label:
-            set_dir.update(_.label.first() for _ in lst if hasattr(_, "label"))
+            dirset.update(_.label.first() for _ in lst if hasattr(_, "label"))
         if self._dir_name:
-            set_dir.update(_.name for _ in lst if hasattr(_, "name"))
+            dirset.update(_.name for _ in lst if hasattr(_, "name"))
 
-        set_dir.difference_update({None})  # get rid of possible None
-        return sorted(set_dir)
+        dirset.difference_update({None})  # get rid of possible None
+        return sorted(dirset)
 
     def __getitem__(self, name):
         item = super().__getitem__(name)
@@ -349,7 +349,13 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             else (a.storid for a in self.label_annotations)
         )
         for annotation_id in annotation_ids:
-            for s, _, _, _ in self._get_data_triples_spod_spod(
+            #
+            # Question to reviewer:
+            # Should we make it an option (turned off by default) to search
+            # only the current ontology?
+            # I have sometimes been wishing for that. It is easily implemented,
+            # just remove ".world" in the line below.
+            for s, _, _, _ in self.world._get_data_triples_spod_spod(
                 None, annotation_id, label, None
             ):
                 return self.world[self._unabbreviate(s)]

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from ontopy import get_ontology
+
+
+thisdir = Path(__file__).resolve().parent
+
+onto = get_ontology(
+    thisdir / "test_excelparser/imported_onto/ontology.ttl"
+).load()
+assert "TestClass2" in dir(onto)
+
+onto.dir_imported = False
+assert "TestClass2" not in dir(onto)
+assert "testclass" not in dir(onto)
+
+onto.dir_imported = True
+onto.dir_name = True
+assert "TestClass2" in dir(onto)
+assert "testclass" in dir(onto)
+assert "testclass2" in dir(onto)

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -9,11 +9,15 @@ onto = get_ontology(
     thisdir / "test_excelparser/imported_onto/ontology.ttl"
 ).load()
 onto.dir_imported = False
+onto.dir_preflabel = False
 onto.dir_label = False
 onto.dir_name = False
 assert "TestClass2" not in dir(onto)
 
 onto.dir_imported = True
+onto.dir_preflabel = True
+assert onto._dir_imported
+assert onto.TestClass2
 assert "TestClass2" in dir(onto)
 assert "testclass" not in dir(onto)
 assert "testclass2" not in dir(onto)

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -8,13 +8,16 @@ thisdir = Path(__file__).resolve().parent
 onto = get_ontology(
     thisdir / "test_excelparser/imported_onto/ontology.ttl"
 ).load()
-assert "TestClass2" in dir(onto)
-
 onto.dir_imported = False
+onto.dir_label = False
+onto.dir_name = False
 assert "TestClass2" not in dir(onto)
-assert "testclass" not in dir(onto)
 
 onto.dir_imported = True
+assert "TestClass2" in dir(onto)
+assert "testclass" not in dir(onto)
+assert "testclass2" not in dir(onto)
+
 onto.dir_name = True
 assert "TestClass2" in dir(onto)
 assert "testclass" in dir(onto)

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -1,0 +1,6 @@
+from ontopy import get_ontology
+
+
+emmo = get_ontology().load()
+assert emmo[emmo.Atom.name] == emmo.Atom
+assert emmo[emmo.Atom.iri] == emmo.Atom

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -1,6 +1,13 @@
 from ontopy import get_ontology
 
 
+# Loading emmo-inferred where everything is sqashed into one ontology
 emmo = get_ontology().load()
 assert emmo[emmo.Atom.name] == emmo.Atom
 assert emmo[emmo.Atom.iri] == emmo.Atom
+
+# Load an ontology with imported sub-ontologies
+onto = get_ontology(
+    "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
+).load()
+assert onto.Electrolyte.prefLabel.first() == "Electrolyte"

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -1,4 +1,7 @@
+import pytest
+
 from ontopy import get_ontology
+from ontopy.ontology import NoSuchLabelError
 
 
 # Loading emmo-inferred where everything is sqashed into one ontology
@@ -11,3 +14,11 @@ onto = get_ontology(
     "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
 ).load()
 assert onto.Electrolyte.prefLabel.first() == "Electrolyte"
+
+
+# Check colon_in_name argument
+onto.Atom.altLabel.append("Element:X")
+with pytest.raises(NoSuchLabelError):
+    onto.get_by_label("Element:X")
+
+assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom


### PR DESCRIPTION
# Description:
The main issue addressed in this PR is to update get_by_label() such that it allows access by name (what follows the hash in the IRI).

However, when we are at it, a few other things have been included:
- access by IRI
- documented how conflict in prefix in label and argument is handled
- allow space in labels
- added test for label, name and full IRI
- added test for dir listing on the ontology (due to codecov complaining)

Closes #583 

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
