### PR TITLE
Change ontology.new_entity to also allow adding properties

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1649,17 +1649,22 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 AnnotationPropertyClass,
             ]
         ] = "class",
-    ) -> ThingClass:
+    ) -> Union[
+        ThingClass,
+        ObjectPropertyClass,
+        DataPropertyClass,
+        AnnotationPropertyClass,
+    ]:
         """Create and return new entity
 
         Args:
             name: name of the entity
             parent: parent(s) of the entity
             entitytype: type of the entity,
-            default is 'class/ThingClass'. Other options
-            are data_property, object_property,
-            annotation_property or ObjectPropertyClass,
-            DataPropertyClass and AnnotationProperty classes.
+                default is 'class/ThingClass'. Other options
+                are data_property, object_property,
+                annotation_property or ObjectPropertyClass,
+                DataPropertyClass and AnnotationProperty classes.
 
         Returns:
             the new entity.
@@ -1707,6 +1712,66 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         with self:
             entity = types.new_class(name, parents)
         return entity
+
+    # Method that creates new ThingClass using new_entity
+    def new_class(
+        self, name: str, parent: Union[ThingClass, Iterable]
+    ) -> ThingClass:
+        """Create and return new class.
+
+        Args:
+            name: name of the class
+            parent: parent(s) of the class
+
+        Returns:
+            the new class.
+        """
+        return self.new_entity(name, parent, "class")
+
+    # Method that creates new ObjectPropertyClass using new_entity
+    def new_object_property(
+        self, name: str, parent: Union[ObjectPropertyClass, Iterable]
+    ) -> ObjectPropertyClass:
+        """Create and return new object property.
+
+        Args:
+            name: name of the object property
+            parent: parent(s) of the object property
+
+        Returns:
+            the new object property.
+        """
+        return self.new_entity(name, parent, "object_property")
+
+    # Method that creates new DataPropertyClass using new_entity
+    def new_data_property(
+        self, name: str, parent: Union[DataPropertyClass, Iterable]
+    ) -> DataPropertyClass:
+        """Create and return new data property.
+
+        Args:
+            name: name of the data property
+            parent: parent(s) of the data property
+
+        Returns:
+            the new data property.
+        """
+        return self.new_entity(name, parent, "data_property")
+
+    # Method that creates new AnnotationPropertyClass using new_entity
+    def new_annotation_property(
+        self, name: str, parent: Union[AnnotationPropertyClass, Iterable]
+    ) -> AnnotationPropertyClass:
+        """Create and return new annotation property.
+
+        Args:
+            name: name of the annotation property
+            parent: parent(s) of the annotation property
+
+        Returns:
+            the new annotation property.
+        """
+        return self.new_entity(name, parent, "annotation_property")
 
 
 class BlankNode:

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1655,14 +1655,19 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         Args:
             name: name of the entity
             parent: parent(s) of the entity
-            entitytype: type of the entity, default is 'class'.Other options
-            are data_property, object_property, annotation_property.
+            entitytype: type of the entity,
+            default is 'class/ThingClass'. Other options
+            are data_property, object_property,
+            annotation_property or ObjectPropertyClass,
+            DataPropertyClass and AnnotationProperty classes.
 
         Returns:
             the new entity.
 
         Throws exception if name consists of more than one word, if type is not
         one of the allowed types, or if parent is not of the correct type.
+        By default, the parent is Thing.
+
         """
         if " " in name:
             raise LabelDefinitionError(

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1661,9 +1661,11 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             name: name of the entity
             parent: parent(s) of the entity
             entitytype: type of the entity,
-                default is 'class/ThingClass'. Other options
-                are data_property, object_property,
-                annotation_property or ObjectPropertyClass,
+                default is 'class' (str) 'ThingClass' (owlready2 Python class).
+                Other options
+                are 'data_property', 'object_property',
+                'annotation_property' (strings) or the
+                Python classes ObjectPropertyClass,
                 DataPropertyClass and AnnotationProperty classes.
 
         Returns:

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -248,7 +248,7 @@ def asstring(  # pylint: disable=too-many-return-statements,too-many-branches,to
         return f"inverse({fmt(expr.property)})"
     if isinstance(expr, owlready2.disjoint.AllDisjoint):
         return fmt(expr)
-    print("expr1", expr)
+
     if isinstance(expr, (bool, int, float)):
         return repr(expr)
     # Check for subclasses

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -137,7 +137,6 @@ def asstring(  # pylint: disable=too-many-return-statements,too-many-branches,to
     """
     if ontology is None:
         ontology = expr.ontology
-    print("exprtio", expr)
 
     def fmt(entity):
         """Returns the formatted label of an entity."""

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 import datetime
+import inspect
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -69,7 +70,7 @@ class LabelDefinitionError(EMMOntoPyException):
     """Error in label definition."""
 
 
-class ThingClassDefinitionError(EMMOntoPyException):
+class EntityClassDefinitionError(EMMOntoPyException):
     """Error in ThingClass definition."""
 
 
@@ -136,6 +137,7 @@ def asstring(  # pylint: disable=too-many-return-statements,too-many-branches,to
     """
     if ontology is None:
         ontology = expr.ontology
+    print("exprtio", expr)
 
     def fmt(entity):
         """Returns the formatted label of an entity."""
@@ -246,17 +248,20 @@ def asstring(  # pylint: disable=too-many-return-statements,too-many-branches,to
         return f"inverse({fmt(expr.property)})"
     if isinstance(expr, owlready2.disjoint.AllDisjoint):
         return fmt(expr)
+    print("expr1", expr)
     if isinstance(expr, (bool, int, float)):
         return repr(expr)
     # Check for subclasses
-    if issubclass(expr, (bool, int, float, str)):
-        return fmt(expr.__class__.__name__)
-    if issubclass(expr, datetime.date):
-        return "date"
-    if issubclass(expr, datetime.time):
-        return "datetime"
-    if issubclass(expr, datetime.datetime):
-        return "datetime"
+    if inspect.isclass(expr):
+        print("expr", expr, type(expr))
+        if issubclass(expr, (bool, int, float, str)):
+            return fmt(expr.__class__.__name__)
+        if issubclass(expr, datetime.date):
+            return "date"
+        if issubclass(expr, datetime.time):
+            return "datetime"
+        if issubclass(expr, datetime.datetime):
+            return "datetime"
 
     raise RuntimeError(f"Unknown expression: {expr!r} (type: {type(expr)!r})")
 

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -253,7 +253,6 @@ def asstring(  # pylint: disable=too-many-return-statements,too-many-branches,to
         return repr(expr)
     # Check for subclasses
     if inspect.isclass(expr):
-        print("expr", expr, type(expr))
         if issubclass(expr, (bool, int, float, str)):
             return fmt(expr.__class__.__name__)
         if issubclass(expr, datetime.date):

--- a/tests/ontopy_tests/test_new_entity.py
+++ b/tests/ontopy_tests/test_new_entity.py
@@ -92,3 +92,11 @@ def test_new_entity(testonto: "Ontology") -> None:
             testonto.hasObjectProperty,
             entitytype="nonexistingpropertytype",
         )
+    testonto.new_class("AnotherClass3", (testonto.AnotherClass,))
+    testonto.new_object_property(
+        "hasSubObjectProperty3", testonto.hasObjectProperty
+    )
+    testonto.new_data_property("hasSubDataProperty3", testonto.hasDataProperty)
+    testonto.new_annotation_property(
+        "hasSubAnnotationProperty3", testonto.hasAnnotationProperty
+    )

--- a/tests/ontopy_tests/test_new_entity.py
+++ b/tests/ontopy_tests/test_new_entity.py
@@ -1,0 +1,94 @@
+from typing import TYPE_CHECKING
+import pytest
+from ontopy.utils import (
+    NoSuchLabelError,
+    LabelDefinitionError,
+    EntityClassDefinitionError,
+)
+from owlready2.entity import ThingClass
+from owlready2.prop import ObjectPropertyClass, DataPropertyClass
+from owlready2 import AnnotationPropertyClass
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_new_entity(testonto: "Ontology") -> None:
+    """Test adding entities to ontology"""
+
+    # Add entity directly
+    testonto.new_entity("FantasyClass", testonto.TestClass)
+
+    # Test that new entity is found by both version of get_by_label
+    assert testonto.get_by_label("FantasyClass") == testonto.FantasyClass
+    assert testonto.get_by_label_all("FantasyClass") == [testonto.FantasyClass]
+
+    testonto.sync_attributes()
+    # Test that after sync_attributes, the entity is not counted more than once
+    assert testonto.get_by_label_all("FantasyClass") == [testonto.FantasyClass]
+
+    with pytest.raises(LabelDefinitionError):
+        testonto.new_entity("Fantasy Class", testonto.TestClass)
+
+    testonto.new_entity(
+        "AnotherClass", testonto.TestClass, entitytype=ThingClass
+    )
+    testonto.new_entity(
+        "hasSubObjectProperty",
+        testonto.hasObjectProperty,
+        entitytype=ObjectPropertyClass,
+    )
+    testonto.new_entity(
+        "hasSubDataProperty",
+        testonto.hasDataProperty,
+        entitytype=DataPropertyClass,
+    )
+    testonto.new_entity(
+        "hasSubAnnotationProperty",
+        testonto.hasAnnotationProperty,
+        entitytype=AnnotationPropertyClass,
+    )
+
+    testonto.sync_attributes()
+    testonto.new_entity(
+        "AnotherClass2", testonto.AnotherClass, entitytype="class"
+    )
+    testonto.new_entity(
+        "hasSubObjectProperty2",
+        testonto.hasSubObjectProperty,
+        entitytype="object_property",
+    )
+    testonto.new_entity(
+        "hasSubDataProperty2",
+        testonto.hasSubDataProperty,
+        entitytype="data_property",
+    )
+    testonto.new_entity(
+        "hasSubAnnotationProperty2",
+        testonto.hasSubAnnotationProperty,
+        entitytype="annotation_property",
+    )
+
+    with pytest.raises(EntityClassDefinitionError):
+        testonto.new_entity("FantasyClass", testonto.hasObjectProperty)
+
+    with pytest.raises(EntityClassDefinitionError):
+        testonto.new_entity(
+            "hasSubProperty",
+            testonto.hasObjectProperty,
+            entitytype="data_property",
+        )
+
+    with pytest.raises(EntityClassDefinitionError):
+        testonto.new_entity(
+            "hasSubProperty",
+            testonto.hasObjectProperty,
+            entitytype=AnnotationPropertyClass,
+        )
+
+    with pytest.raises(EntityClassDefinitionError):
+        testonto.new_entity(
+            "hasSubProperty",
+            testonto.hasObjectProperty,
+            entitytype="nonexistingpropertytype",
+        )

--- a/tests/ontopy_tests/test_prefix.py
+++ b/tests/ontopy_tests/test_prefix.py
@@ -9,10 +9,15 @@ if TYPE_CHECKING:
 def test_prefix(testonto: "Ontology", emmo: "Ontology") -> None:
     """Test prefix in ontology"""
 
-    assert len(testonto.get_by_label_all("*")) == 3
-    assert testonto.get_by_label_all("*", prefix="testonto") == [
-        testonto.TestClass
-    ]
+    assert len(testonto.get_by_label_all("*")) == 6
+    assert set(testonto.get_by_label_all("*", prefix="testonto")) == set(
+        [
+            testonto.hasObjectProperty,
+            testonto.TestClass,
+            testonto.hasAnnotationProperty,
+            testonto.hasDataProperty,
+        ]
+    )
     assert (
         testonto.get_by_label("TestClass", prefix="testonto")
         == testonto.TestClass

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 def test_basic(emmo: "Ontology") -> None:
     from ontopy import get_ontology
-    from ontopy.utils import LabelDefinitionError
+    from ontopy.utils import LabelDefinitionError, EntityClassDefinitionError
 
     onto = get_ontology("onto.owl")
     onto.imported_ontologies.append(emmo)
@@ -28,6 +28,9 @@ def test_basic(emmo: "Ontology") -> None:
 
     with pytest.raises(LabelDefinitionError):
         onto.new_entity("Hydr ogen", emmo.Atom)
+
+    with pytest.raises(EntityClassDefinitionError):
+        onto.new_entity("Hydrogen", emmo.hasPart)
 
     with onto:
         # Add entity using python classes

--- a/tests/testonto/testonto.ttl
+++ b/tests/testonto/testonto.ttl
@@ -16,3 +16,18 @@
 :testclass rdf:type owl:Class ;
     rdfs:subClassOf owl:Thing ;
     skos:prefLabel "TestClass"@en .
+
+:testobjectproperty rdf:type owl:ObjectProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range :testclass ;
+    skos:prefLabel "hasObjectProperty"@en .
+
+:testannotationproperty rdf:type owl:AnnotationProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range rdfs:Literal ;
+    skos:prefLabel "hasAnnotationProperty"@en .
+
+:testdatatypeproperty rdf:type owl:DatatypeProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range xsd:string ;
+    skos:prefLabel "hasDataProperty"@en .


### PR DESCRIPTION
# Description
new_entity adds a ThingClass as default  as before, but it is now possble to add annotation/object/dataproperties as well.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [x] Documentation update.
- [x] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
