### PR TITLE
Item access to classes

### DIFF
--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -5,7 +5,7 @@ import types
 import owlready2
 from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
 from owlready2 import Metadata
-from ontopy.utils import EMMOntoPyException, get_label
+from ontopy.utils import EMMOntoPyException
 
 
 def render_func(entity):
@@ -76,10 +76,8 @@ def _dir(self):
 
 def _getitem(self, name):
     """Provide item access to properties."""
-    onto = self.namespace.ontology
-    labels = {get_label(prop) for prop in onto.properties()}
-    # labels.update(('is_a', 'equivalent_to', 'disjoint_unions'))
-    if name in labels:
+    prop = self.namespace.ontology.get_by_label(name)
+    if isinstance(prop, PropertyClass):
         return getattr(self, name)
     raise KeyError(f"no such property: {name}")
 

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -3,8 +3,8 @@
 import types
 
 import owlready2
-from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
-from owlready2 import Metadata
+from owlready2 import AnnotationPropertyClass, ThingClass, PropertyClass
+from owlready2 import Metadata, Thing, Restriction, Namespace
 from ontopy.utils import EMMOntoPyException
 
 
@@ -75,15 +75,15 @@ def _dir(self):
 
 
 def _getitem(self, name):
-    """Provide item access to properties."""
+    """Provide item access to annotation properties."""
     prop = self.namespace.ontology.get_by_label(name)
-    if isinstance(prop, PropertyClass):
+    if isinstance(prop, AnnotationPropertyClass):
         return getattr(self, name)
-    raise KeyError(f"no such property: {name}")
+    raise KeyError(f"no such annotation property: {name}")
 
 
 def _setitem(self, name, value):
-    """Provide item asignment for properties.
+    """Provide item asignment for annotation properties.
 
     Note, this appends `value` to the property instead of replacing the
     property.  This is consistent with Owlready2, but may be little
@@ -104,7 +104,7 @@ def _setitem(self, name, value):
 
 
 def _delitem(self, name):
-    """Provide item deletion for properties.
+    """Provide item deletion for annotation properties.
 
     Note, this simply clears the named property.
     """

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -2,6 +2,8 @@
 
 Implemented as a script, such that it easy to understand and use for debugging.
 """
+import pytest
+
 from ontopy import get_ontology
 
 from owlready2 import owl, Inverse
@@ -26,8 +28,11 @@ assert set(emmo.Atom.get_annotations().keys()) == {
 }
 
 
-# Test item access/assignment/deletion for ThingClass
+# Test item access/assignment/deletion for classes
 assert emmo.Atom["altLabel"] == ["ChemicalElement"]
+
+with pytest.raises(KeyError):
+    emmo.Atom["hasPart"]
 
 emmo.Atom["altLabel"] = "Element"
 assert emmo.Atom["altLabel"] == ["ChemicalElement", "Element"]

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -25,6 +25,20 @@ assert set(emmo.Atom.get_annotations().keys()) == {
     "elucidation",
 }
 
+
+# Test item access/assignment/deletion for ThingClass
+assert emmo.Atom["altLabel"] == ["ChemicalElement"]
+
+emmo.Atom["altLabel"] = "Element"
+assert emmo.Atom["altLabel"] == ["ChemicalElement", "Element"]
+
+del emmo.Atom["altLabel"]
+assert emmo.Atom["altLabel"] == []
+
+emmo.Atom["altLabel"] = "ChemicalElement"
+assert emmo.Atom["altLabel"] == ["ChemicalElement"]
+
+
 # TODO: Fix disjoint_with().
 # It seems not to take into account disjoint unions.
 # assert set(emmo.Collection.disjoint_with()) == {emmo.Item}


### PR DESCRIPTION
# Description
Added item access, assignment and deletion to classes.

For now only annotation properties are supported. Rationale:
- only annotations are directly related to a class - all other properties are restrictions
- is_a, equivalent_to, disjoint_unions, disjoints, ... could be supported. But how do do the selection? And what is the added value compared to access these as attributes or methods directly?

## Type of change
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
