### PR TITLE
Added doctest

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -88,7 +88,7 @@ jobs:
         pip install -U -e .[dev]
 
     - name: Test
-      run: pytest -vvv --cov=ontopy --cov=emmopy --cov-report=xml --cov-report=term
+      run: pytest -vvv --cov=ontopy --cov=emmopy --cov-report=xml --cov-report=term --doctest-modules
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.7' && github.repository == 'emmo-repo/EMMOntoPy'

--- a/examples/ontology-from-excel/make_microstructure_onto.py
+++ b/examples/ontology-from-excel/make_microstructure_onto.py
@@ -1,11 +1,15 @@
 """
 python example for creating ontology from excel
 """
+from pathlib import Path
+
 from ontopy.excelparser import create_ontology_from_excel
 from ontopy.utils import write_catalog
 
+
+thisdir = Path(__file__).resolve().parent
 ontology, catalog, errdict = create_ontology_from_excel(
-    "tool/microstructure.xlsx"
+    thisdir / "tool/microstructure.xlsx"
 )
 
 ontology.save("microstructure_ontology.ttl", format="turtle", overwrite=True)

--- a/ontopy/manchester.py
+++ b/ontopy/manchester.py
@@ -94,7 +94,7 @@ def evaluate(ontology: owlready2.Ontology, expr: str) -> owlready2.Construct:
     Example:
     >>> from ontopy.manchester import evaluate
     >>> from ontopy import get_ontology
-    >>> emmo = get_ontology.load()
+    >>> emmo = get_ontology().load()
 
     >>> restriction = evaluate(emmo, 'hasPart some Atom')
     >>> cls = evaluate(emmo, 'Atom')

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -94,7 +94,7 @@ def _setitem(self, name, value):
     >>> emmo = get_emmo()
     >>> emmo.Atom['altLabel']
     ['ChemicalElement']
-    emmo.Atom['altLabel'] = 'Element'
+    >>> emmo.Atom['altLabel'] = 'Element'
     >>> emmo.Atom['altLabel']
     ['ChemicalElement', 'Element']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ disable = [
 
 [tool.pylint.format]
 max-line-length = "80"
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ disable = [
 max-line-length = "80"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = "--doctest-modules --ignore=demo --ignore=docs/demo --ignore=examples --ignore=docs/examples --ignore=site"

--- a/tests/ontopy_tests/test_graph.py
+++ b/tests/ontopy_tests/test_graph.py
@@ -7,6 +7,9 @@ if TYPE_CHECKING:
     from ontopy.ontology import Ontology
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Style not defined for relation hasSpecialRelation:UserWarning"
+)
 def test_graph(testonto: "Ontology", tmpdir: "Path") -> None:
     """Testing OntoGraph on a small ontology
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from ontopy.ontology import Ontology
 
 
+@pytest.mark.filterwarnings("ignore:adding new IRI to ontology:UserWarning")
 def test_basic(emmo: "Ontology") -> None:
     from ontopy import get_ontology
     from ontopy.utils import LabelDefinitionError, EntityClassDefinitionError

--- a/tests/test_excelparser/test_excelparser.py
+++ b/tests/test_excelparser/test_excelparser.py
@@ -1,6 +1,7 @@
 """Test the Excel parser module."""
-import pytest
 from typing import TYPE_CHECKING
+
+import pytest
 
 from ontopy import get_ontology
 from ontopy.excelparser import create_ontology_from_excel
@@ -10,6 +11,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+@pytest.mark.filterwarnings("ignore:Ignoring concept :UserWarning")
+@pytest.mark.filterwarnings("ignore:Invalid parents for :UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:Not able to add the following concepts :UserWarning"
+)
 def test_excelparser(repo_dir: "Path") -> None:
     """Basic test for creating an ontology from an Excel file."""
     ontopath = (

--- a/tests/tools/test_excel2onto.py
+++ b/tests/tools/test_excel2onto.py
@@ -1,12 +1,15 @@
 """Test the `ontograph` tool."""
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
     from typing import Callable
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
     """Check that running `excel2onto` works.
 


### PR DESCRIPTION
# Description
Added testing of examples in documentation using [doctest](https://docs.python.org/3/library/doctest.html).

We can now add examples to our docstrings and test that they actually works. Just format the docstring the [standard way](https://mkdocstrings.github.io/griffe/docstrings/#examples):

```python
>>> from emmopy import get_emmo
>>> emmo = get_emmo().load()
>>> emmo.Atom
emmo.Atom
```

Also ignored some pytest warnings. I think that those that remain should be dealt with...


## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [x] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
