### PR TITLE
Fixed failing tests in test_patch.py

### DIFF
--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -92,11 +92,11 @@ def _setitem(self, name, value):
     Example:
     >>> from emmopy import get_emmo
     >>> emmo = get_emmo()
-    >>> set(emmo.Atom['altLabel'])
-    {'ChemicalElement'}
+    >>> emmo.Atom['altLabel']
+    ['ChemicalElement']
     >>> emmo.Atom['altLabel'] = 'Element'
-    >>> set(emmo.Atom['altLabel'])
-    {'ChemicalElement', 'Element'}
+    >>> emmo.Atom['altLabel']
+    ['ChemicalElement', 'Element']
 
     """
     item = _getitem(self, name)

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -92,11 +92,11 @@ def _setitem(self, name, value):
     Example:
     >>> from emmopy import get_emmo
     >>> emmo = get_emmo()
-    >>> emmo.Atom['altLabel']
-    ['ChemicalElement']
+    >>> set(emmo.Atom['altLabel'])
+    {'ChemicalElement'}
     >>> emmo.Atom['altLabel'] = 'Element'
-    >>> emmo.Atom['altLabel']
-    ['ChemicalElement', 'Element']
+    >>> set(emmo.Atom['altLabel'])
+    {'ChemicalElement', 'Element'}
 
     """
     item = _getitem(self, name)

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -52,8 +52,9 @@ assert emmo.Holistic.is_defined == True
 # Comment out these tests for now because Owlready2 automatically converts
 # `Inverse(emmo.hasPart)` to `emmo.isPartOf`.
 #
-# Also, decide whether we really want to keep get_indirect_is_a() - it
-# very much dublicates what ancestors() already does.
+# Also, check whether ancestors() does any inferences from disjoint unions, etc.
+# If it does, it might be better to reley on ancestors() instead of implementing
+# get_indirect_is_a() as a separate method
 # assert emmo.CausalChain.get_indirect_is_a() == {
 #    Inverse(emmo.hasPart).value(emmo.universe),
 #    emmo.CausalParticle,

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -15,27 +15,24 @@ emmo = get_ontology().load()
 # Test some ThingClass extensions implemented in patch.py
 assert emmo.Atom.get_preferred_label() == "Atom"
 
-assert emmo.Atom.get_parents() == {
-    emmo.CausalSystem,
-    emmo.CompositeParticle,
-    emmo.MolecularEntity,
-}
+assert emmo.Atom.get_parents() == {emmo.MolecularEntity}
 
 assert set(emmo.Atom.get_annotations().keys()) == {
     "prefLabel",
     "altLabel",
     "elucidation",
+    "comment",
 }
 
 
 # Test item access/assignment/deletion for classes
-assert emmo.Atom["altLabel"] == ["ChemicalElement"]
+assert set(emmo.Atom["altLabel"]) == {"ChemicalElement"}
 
 with pytest.raises(KeyError):
     emmo.Atom["hasPart"]
 
 emmo.Atom["altLabel"] = "Element"
-assert emmo.Atom["altLabel"] == ["ChemicalElement", "Element"]
+assert set(emmo.Atom["altLabel"]) == {"ChemicalElement", "Element"}
 
 del emmo.Atom["altLabel"]
 assert emmo.Atom["altLabel"] == []
@@ -44,37 +41,35 @@ emmo.Atom["altLabel"] = "ChemicalElement"
 assert emmo.Atom["altLabel"] == ["ChemicalElement"]
 
 
+assert emmo.Atom.is_defined == False
+assert emmo.Holistic.is_defined == True
+
 # TODO: Fix disjoint_with().
 # It seems not to take into account disjoint unions.
 # assert set(emmo.Collection.disjoint_with()) == {emmo.Item}
 
-assert set(str(s) for s in emmo.CausalChain.get_indirect_is_a()) == set(
-    str(s)
-    for s in {
-        Inverse(emmo.hasPart).value(emmo.universe),
-        emmo.CausalObject,
-        emmo.Particle,
-        emmo.hasPart.some(emmo.Quantum),
-        emmo.hasTemporalPart.only(emmo.CausalChain | emmo.Quantum),
-        emmo.hasTemporalPart.some(emmo.CausalChain | emmo.Quantum),
-    }
-)
-assert set(
-    str(s) for s in emmo.CausalChain.get_indirect_is_a(skip_classes=False)
-) == set(
-    str(s)
-    for s in {
-        Inverse(emmo.hasPart).value(emmo.universe),
-        emmo.CausalObject,
-        emmo.EMMO,
-        emmo.Item,
-        emmo.Particle,
-        emmo.hasPart.some(emmo.Quantum),
-        emmo.hasTemporalPart.only(emmo.CausalChain | emmo.Quantum),
-        emmo.hasTemporalPart.some(emmo.CausalChain | emmo.Quantum),
-        owl.Thing,
-    }
-)
 
-assert emmo.Atom.is_defined == False
-assert emmo.Holistic.is_defined == True
+# Comment out these tests for now because Owlready2 automatically converts
+# `Inverse(emmo.hasPart)` to `emmo.isPartOf`.
+#
+# Also, decide whether we really want to keep get_indirect_is_a() - it
+# very much dublicates what ancestors() already does.
+# assert emmo.CausalChain.get_indirect_is_a() == {
+#    Inverse(emmo.hasPart).value(emmo.universe),
+#    emmo.CausalParticle,
+#    emmo.CausalStructure,
+#    emmo.hasPart.some(emmo.Quantum),
+#    emmo.hasTemporalPart.only(emmo.CausalPath | emmo.Quantum),
+#    emmo.hasTemporalPart.some(emmo.CausalPath | emmo.Quantum),
+# }
+# assert emmo.CausalChain.get_indirect_is_a(skip_classes=False) == {
+#    Inverse(emmo.hasPart).value(emmo.universe),
+#    emmo.CausalObject,
+#    emmo.EMMO,
+#    emmo.Item,
+#    emmo.Particle,
+#    emmo.hasPart.some(emmo.Quantum),
+#    emmo.hasTemporalPart.only(emmo.CausalChain | emmo.Quantum),
+#    emmo.hasTemporalPart.some(emmo.CausalChain | emmo.Quantum),
+#    owl.Thing,
+# }

--- a/tests/test_manchester.py
+++ b/tests/test_manchester.py
@@ -58,16 +58,16 @@ def test_manchester():
         Inverse(emmo.hasPart).value(emmo.universe),
     )
     # literal data restriction
-    check('hasSymbolData value "hello"', emmo.hasSymbolData.value("hello"))
-    check("hasSymbolData value 42", emmo.hasSymbolData.value(42))
-    check("hasSymbolData value 3.14", emmo.hasSymbolData.value(3.14))
+    check('hasSymbolValue value "hello"', emmo.hasSymbolValue.value("hello"))
+    check("hasSymbolValue value 42", emmo.hasSymbolValue.value(42))
+    check("hasSymbolValue value 3.14", emmo.hasSymbolValue.value(3.14))
     check(
-        'hasSymbolData value "abc"^^xsd:string',
-        emmo.hasSymbolData.value("abc"),
+        'hasSymbolValue value "abc"^^xsd:string',
+        emmo.hasSymbolValue.value("abc"),
     )
     check(
-        'hasSymbolData value "hello"@en',
-        emmo.hasSymbolData.value(locstr("hello", "en")),
+        'hasSymbolValue value "hello"@en',
+        emmo.hasSymbolValue.value(locstr("hello", "en")),
     )
     check("emmo:hasPart some emmo:Atom", emmo.hasPart.some(emmo.Atom))
 


### PR DESCRIPTION
# Description
Due to resent updates in EMMO, several of the tests in test_patch.py were failing.

We should consider to test against our test ontology instead of EMMO to avoid such failures.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [x] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
