### PR TITLE
Check prefLabels in imported ontologies only if asked for.

### DIFF
--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -89,12 +89,11 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
         exceptions.update(
             self.get_config("test_number_of_labels.exceptions", ())
         )
-
         if (
             "prefLabel"
             in self.onto.world._props  # pylint: disable=protected-access
         ):
-            for entity in self.onto.get_entities():
+            for entity in self.onto.classes(self.check_imported):
                 if repr(entity) not in exceptions:
                     with self.subTest(
                         entity=entity,

--- a/ontopy/manchester.py
+++ b/ontopy/manchester.py
@@ -45,11 +45,11 @@ def manchester_expression():
     literal = (
         typedLiteral | stringLanguageLiteral | stringLiteral | numberLiteral
     )
-    logOp = pp.oneOf(["and", "or"], asKeyword=True)
+    logOp = pp.one_of(["and", "or"], asKeyword=True)
     expr = pp.Forward()
     restriction = pp.Forward()
     primary = pp.Keyword("not")[...] + (
-        restriction | ident("cls") | pp.nestedExpr("(", ")", expr)
+        restriction | ident("cls") | pp.nested_expr("(", ")", expr)
     )
     objPropExpr = (
         pp.Literal("inverse")


### PR DESCRIPTION
# Description
The check for number of prefLabels was done on all classes including imported, even if imported is not given.
This is now corrected.

Also, for some reason updates in pyparsing in which methods have been renamed to python names with _ from camelcase made pylint fail, but is now fixed.


## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
