### PR TITLE
Simplified implementation of label_annotations.

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -98,9 +98,10 @@ class World(owlready2.World):
             OntologyClass: If given and `base_iri` doesn't correspond
                 to an existing ontology, a new ontology is created of
                 this Ontology subclass.
-            label_annotations: Sequence of IRIs used for accessing
-                classes in the ontology.  The default correspond to
-                skos:prefLabel, rdfs:label and skos:altLabel.
+            label_annotations: Sequence of label IRIs used for accessing
+                entities in the ontology given that they are in the ontology.
+                Label IRIs not in the ontology will simply be ignored.
+                Detault to DEFAULT_LABEL_ANNOTATIONS module variable.
         """
         base_iri = base_iri.as_uri() if isinstance(base_iri, Path) else base_iri
 
@@ -494,6 +495,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                     storids.append(storid)
         return storids
 
+    # REMOVE - NOT CURRENTLY USED...
     def _to_entities(self, sequence, create_if_missing=False):
         """Like _to_storids(), but return a list of entities corresponding
         to the elements in `sequence`.

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -4,7 +4,7 @@ from ontopy import get_ontology
 from ontopy.ontology import NoSuchLabelError
 
 
-def test_get_by_label_onto() -> None:
+def test_get_by_label_onto(repo_dir) -> None:
     """Test that label annotations are added correctly if they are not added before
     using get_by_label
     """
@@ -12,17 +12,23 @@ def test_get_by_label_onto() -> None:
 
     testonto = get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
-    assert testonto._label_annotations == None
+
+    # THIS IS NOT NONE ANYMORE
+    # assert testonto.label_annotations == None
+
     assert testonto.get_by_label("Class") == testonto.Class
 
-    imported_onto = world.get_ontology(
+    imported_onto = testonto.world.get_ontology(
         repo_dir / "tests" / "testonto" / "testonto.ttl"
     ).load()
     testonto.imported_ontologies.append(imported_onto)
     assert imported_onto.get_by_label("TestClass")
     assert imported_onto.get_by_label("models:TestClass")
-    testonto.set_default_label_annotations()
-    assert testonto.get_by_label("testclass")
+
+    # THIS IS NOW DEPRECATED
+    # testonto.set_default_label_annotations()
+
+    assert testonto.get_by_label("TestClass")
 
 
 def test_get_by_label_all_onto() -> None:
@@ -33,29 +39,27 @@ def test_get_by_label_all_onto() -> None:
 
     testonto = get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
-    assert testonto._label_annotations == None
     assert testonto.get_by_label_all("*") == {testonto.Class}
     testonto.new_annotation_property(
         "SpecialAnnotation", owlready2.AnnotationProperty
     )
     testonto.Class.SpecialAnnotation.append("This is a comment")
-    testonto.set_default_label_annotations()
 
     testonto.new_entity("Klasse", testonto.Class)
 
-    assert testonto.Klasse.prefLabel == ["Klasse"]
-
-    testonto.Klasse.altLabel = "Class2"
+    # THESE NOW FAILS, SINCE prefLabel AND altLabel ARE NOT DEFINED in testonto
+    # I THINK THIS IS THE RIGHT BEHAVIOUR.
+    # assert testonto.Klasse.prefLabel == ["Klasse"]
+    # testonto.Klasse.altLabel = "Class2"
     assert testonto.get_by_label_all("*") == {
-        testonto.prefLabel,
-        testonto.altLabel,
+        # testonto.prefLabel,
+        # testonto.altLabel,
         testonto.Class,
         testonto.SpecialAnnotation,
         testonto.Klasse,
     }
     assert testonto.get_by_label_all("Class*") == {
         testonto.Class,
-        testonto.Klasse,
     }
 
 

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -9,13 +9,12 @@ def test_get_by_label_onto(repo_dir) -> None:
     using get_by_label
     """
     import owlready2
+    from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
 
     testonto = get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
 
-    # THIS IS NOT NONE ANYMORE
-    # assert testonto.label_annotations == None
-
+    assert testonto.label_annotations == DEFAULT_LABEL_ANNOTATIONS
     assert testonto.get_by_label("Class") == testonto.Class
 
     imported_onto = testonto.world.get_ontology(
@@ -24,9 +23,6 @@ def test_get_by_label_onto(repo_dir) -> None:
     testonto.imported_ontologies.append(imported_onto)
     assert imported_onto.get_by_label("TestClass")
     assert imported_onto.get_by_label("models:TestClass")
-
-    # THIS IS NOW DEPRECATED
-    # testonto.set_default_label_annotations()
 
     assert testonto.get_by_label("TestClass")
 
@@ -47,10 +43,18 @@ def test_get_by_label_all_onto() -> None:
 
     testonto.new_entity("Klasse", testonto.Class)
 
-    # THESE NOW FAILS, SINCE prefLabel AND altLabel ARE NOT DEFINED in testonto
-    # I THINK THIS IS THE RIGHT BEHAVIOUR.
+    with pytest.raises(AttributeError):
+        assert testonto.Klasse.prefLabel == ["Klasse"]
+
+    # Add prefLabel to ontology
+    # preflabel = testonto.new_annotation_property(
+    #    "prefLabel", parent=[owlready2.AnnotationPropertyClass],
+    # )
+    # preflabel.iri = "http://www.w3.org/2004/02/skos/core#prefLabel"
+    # assert testonto.prefLabel.prefLabel == ["prefLabel"]
+    #
     # assert testonto.Klasse.prefLabel == ["Klasse"]
-    # testonto.Klasse.altLabel = "Class2"
+
     assert testonto.get_by_label_all("*") == {
         # testonto.prefLabel,
         # testonto.altLabel,

--- a/tests/test_get_by_label_new.py
+++ b/tests/test_get_by_label_new.py
@@ -14,7 +14,10 @@ def test_get_by_label_onto(repo_dir) -> None:
     world = ontopy.World()
     testonto = world.get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
-    assert testonto._label_annotations == None
+
+    # THIS IS NOT NONE ANYMORE
+    # assert testonto._label_annotations == None
+
     assert testonto.get_by_label("Class") == testonto.Class
 
     imported_onto = world.get_ontology(


### PR DESCRIPTION
# Description
Simplified the implementation of `label_annotations`. The `label_annotations` property is now a list of full IRI's to label annotations that will be used by `get_by_label()` given that the IRI is in the world of the ontology. 

Hence, if the ontology doesn't define `skos:prefLabel` it will not be used by `get_by_label()`  even though that "http://www.w3.org/2004/02/skos/core#prefLabel" may be included in `onto.label_annotations`.

I think this make things behave as expected in common cases without the user having to fickle with `label_annotations`.

The label annotations that are currently used by `get_by_label()` can be listed with 

    onto._to_entities(onto.label_annotations)

I also deprecated some functions that I only think increases the complexity without providing any real value.

See also comments IN CAPITALS. They should be removed before merging to master.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
