### PR TITLE
Corrected get_by_label to use only labels in the ontology

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1783,7 +1783,6 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 f"Label consists of more than one word."
             )
         parents = tuple(parent) if isinstance(parent, Iterable) else (parent,)
-
         if entitytype == "class":
             parenttype = owlready2.ThingClass
         elif entitytype == "data_property":
@@ -1817,10 +1816,11 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             preflabel_iri = "http://www.w3.org/2004/02/skos/core#prefLabel"
             if preflabel:
                 if not self.world[preflabel_iri]:
-                    prefLabel = types.new_class(
-                        "prefLabel", [owlready2.AnnotationProperty]
+                    pref_label = self.new_annotation_property(
+                        "prefLabel",
+                        parent=[owlready2.AnnotationProperty],
                     )
-                    prefLabel.iri = preflabel_iri
+                    pref_label.iri = preflabel_iri
                 entity.prefLabel = english(preflabel)
             elif (
                 preflabel is None

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -100,8 +100,9 @@ class World(owlready2.World):
                 this Ontology subclass.  Defaults to `ontopy.Ontology`.
             label_annotations: Sequence of label IRIs used for accessing
                 entities in the ontology given that they are in the ontology.
-                Label IRIs not in the ontology will simply be ignored.
-                Detault to DEFAULT_LABEL_ANNOTATIONS module variable.
+                Label IRIs not in the ontology will need to be added to
+                ontologies in order to be accessible.
+                Default is None.
         """
         base_iri = base_iri.as_uri() if isinstance(base_iri, Path) else base_iri
 
@@ -533,7 +534,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
     def remove_label_annotation(self, iri):
         """Removes label annotation used by get_by_label()."""
         warnings.warn(
-            "Ontology.add_label_annotations() is deprecated. "
+            "Ontology.remove_label_annotations() is deprecated. "
             "Direct modify the `label_annotations` attribute instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -415,7 +415,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         prefix=None,
         exact_match=False,
     ):
-        """Like get_by_label(), but returns a list with all matching labels.
+        """Returns list of entities with label annotation `label`.
 
         Arguments:
            label: label so search for.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -102,7 +102,7 @@ class World(owlready2.World):
                 entities in the ontology given that they are in the ontology.
                 Label IRIs not in the ontology will need to be added to
                 ontologies in order to be accessible.
-                Default is None.
+                Defaults to DEFAULT_LABEL_ANNOTATIONS if set to None.
         """
         base_iri = base_iri.as_uri() if isinstance(base_iri, Path) else base_iri
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -414,8 +414,8 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         label_annotations=None,
         prefix=None,
         exact_match=False,
-    ):
-        """Returns list of entities with label annotation `label`.
+    ) -> "Set[Optional[owlready2.entity.EntityClass]]":
+        """Returns set of entities with label annotation `label`.
 
         Arguments:
            label: label so search for.
@@ -433,7 +433,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                containing such labels.
 
         Returns:
-            List of all matching entities or an empty list if no matches
+            Set of all matching entities or an empty set if no matches
             could be found.
         """
         if not isinstance(label, str):

--- a/tests/ontopy_tests/test_deprecation_warnings.py
+++ b/tests/ontopy_tests/test_deprecation_warnings.py
@@ -1,8 +1,5 @@
 from typing import TYPE_CHECKING
 import pytest
-from owlready2.entity import ThingClass
-from owlready2.prop import ObjectPropertyClass, DataPropertyClass
-from owlready2 import AnnotationPropertyClass
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/ontopy_tests/test_deprecation_warnings.py
+++ b/tests/ontopy_tests/test_deprecation_warnings.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+import pytest
+from owlready2.entity import ThingClass
+from owlready2.prop import ObjectPropertyClass, DataPropertyClass
+from owlready2 import AnnotationPropertyClass
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Ontology.add_label_annotations() is deprecated. Direct modify the `label_annotations` attribute instead."
+)
+def test_deprecation_warnings() -> None:
+    """Test functionalities will be removed and currently have depracation warnings"""
+    from ontopy import get_ontology
+    from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
+
+    testonto = get_ontology("http://domain_ontology/new_ontology")
+
+    testonto.add_label_annotation(DEFAULT_LABEL_ANNOTATIONS[0])
+
+    testonto.remove_label_annotation(DEFAULT_LABEL_ANNOTATIONS[0])

--- a/tests/ontopy_tests/test_new_entity.py
+++ b/tests/ontopy_tests/test_new_entity.py
@@ -33,6 +33,14 @@ def test_new_entity(testonto: "Ontology") -> None:
     testonto.new_entity(
         "AnotherClass", testonto.TestClass, entitytype=ThingClass
     )
+
+    testonto.new_entity(
+        "YetAnotherClass",
+        testonto.TestClass,
+        entitytype=ThingClass,
+        preflabel="YetAnotherClass",
+    )
+
     testonto.new_entity(
         "hasSubObjectProperty",
         testonto.hasObjectProperty,
@@ -99,4 +107,15 @@ def test_new_entity(testonto: "Ontology") -> None:
     testonto.new_data_property("hasSubDataProperty3", testonto.hasDataProperty)
     testonto.new_annotation_property(
         "hasSubAnnotationProperty3", testonto.hasAnnotationProperty
+    )
+
+    from ontopy import get_ontology
+    from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
+
+    testonto2 = get_ontology("http://domain_ontology/new_ontology")
+    testonto2.new_entity(
+        "NewClass",
+        testonto.TestClass,
+        entitytype=ThingClass,
+        preflabel="NewClass",
     )

--- a/tests/ontopy_tests/test_new_entity.py
+++ b/tests/ontopy_tests/test_new_entity.py
@@ -1,13 +1,5 @@
 from typing import TYPE_CHECKING
 import pytest
-from ontopy.utils import (
-    NoSuchLabelError,
-    LabelDefinitionError,
-    EntityClassDefinitionError,
-)
-from owlready2.entity import ThingClass
-from owlready2.prop import ObjectPropertyClass, DataPropertyClass
-from owlready2 import AnnotationPropertyClass
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -15,6 +7,14 @@ if TYPE_CHECKING:
 
 def test_new_entity(testonto: "Ontology") -> None:
     """Test adding entities to ontology"""
+    from ontopy.utils import (
+        NoSuchLabelError,
+        LabelDefinitionError,
+        EntityClassDefinitionError,
+    )
+    from owlready2.entity import ThingClass
+    from owlready2.prop import ObjectPropertyClass, DataPropertyClass
+    from owlready2 import AnnotationPropertyClass
 
     # Add entity directly
     testonto.new_entity("FantasyClass", testonto.TestClass)
@@ -109,13 +109,17 @@ def test_new_entity(testonto: "Ontology") -> None:
         "hasSubAnnotationProperty3", testonto.hasAnnotationProperty
     )
 
+
+def test_new_entity_w_preflabel() -> None:
+    """Test adding entities to ontology"""
     from ontopy import get_ontology
-    from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
+    import owlready2
 
     testonto2 = get_ontology("http://domain_ontology/new_ontology")
     testonto2.new_entity(
         "NewClass",
-        testonto.TestClass,
-        entitytype=ThingClass,
+        owlready2.Thing,
         preflabel="NewClass",
     )
+
+    # assert testonto2.NewClass.preflabel == "NewClass"

--- a/tests/ontopy_tests/test_ontology_helper_functions.py
+++ b/tests/ontopy_tests/test_ontology_helper_functions.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING
+import pytest
+from owlready2.entity import ThingClass
+from owlready2.prop import ObjectPropertyClass, DataPropertyClass
+from owlready2 import AnnotationPropertyClass
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_ontology_to_storids(testonto: "Ontology") -> None:
+    """Test adding helper functions in ontopy.ontology"""
+    from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
+
+    label_annotations = DEFAULT_LABEL_ANNOTATIONS
+    assert len(testonto._to_storids(label_annotations)) == 3
+    assert testonto._to_storids(None) == []
+    assert testonto._to_storids([testonto.TestClass])

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -11,31 +11,14 @@ def test_get_by_label_onto(repo_dir) -> None:
     import owlready2
     from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
 
+    # create ontology with one class and check that it is found 
     testonto = get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
 
     assert testonto.label_annotations == DEFAULT_LABEL_ANNOTATIONS
     assert testonto.get_by_label("Class") == testonto.Class
-
-    imported_onto = testonto.world.get_ontology(
-        repo_dir / "tests" / "testonto" / "testonto.ttl"
-    ).load()
-    testonto.imported_ontologies.append(imported_onto)
-    assert imported_onto.get_by_label("TestClass")
-    assert imported_onto.get_by_label("models:TestClass")
-
-    assert testonto.get_by_label("TestClass")
-
-
-def test_get_by_label_all_onto() -> None:
-    """Test that label annotations are added correctly if they are not added before
-    using get_by_label_all
-    """
-    import owlready2
-
-    testonto = get_ontology("http://domain_ontology/new_ontology")
-    testonto.new_entity("Class", owlready2.Thing)
     assert testonto.get_by_label_all("*") == {testonto.Class}
+    
     testonto.new_annotation_property(
         "SpecialAnnotation", owlready2.AnnotationProperty
     )
@@ -46,26 +29,51 @@ def test_get_by_label_all_onto() -> None:
     with pytest.raises(AttributeError):
         assert testonto.Klasse.prefLabel == ["Klasse"]
 
-    # Add prefLabel to ontology
-    # preflabel = testonto.new_annotation_property(
-    #    "prefLabel", parent=[owlready2.AnnotationPropertyClass],
-    # )
-    # preflabel.iri = "http://www.w3.org/2004/02/skos/core#prefLabel"
-    # assert testonto.prefLabel.prefLabel == ["prefLabel"]
-    #
-    # assert testonto.Klasse.prefLabel == ["Klasse"]
-
     assert testonto.get_by_label_all("*") == {
-        # testonto.prefLabel,
-        # testonto.altLabel,
         testonto.Class,
         testonto.SpecialAnnotation,
         testonto.Klasse,
     }
+
+    # Add prefLabel to ontology
+    preflabel = testonto.new_annotation_property(
+       "prefLabel", parent=[owlready2.AnnotationProperty],
+    )
+    preflabel.iri = "http://www.w3.org/2004/02/skos/core#prefLabel"
+
+    # After prefLabel was added to the ontology, prefLabels can be accessed
+    with pytest.raises(AssertionError):
+        assert testonto.prefLabel.prefLabel == ["prefLabel"]
+    testonto.prefLabel.prefLabel = "prefLabel"
+    assert testonto.prefLabel.prefLabel == ["prefLabel"]
+ 
+    with pytest.raises(AssertionError):
+        assert testonto.Klasse.prefLabel == ["Klasse"]
+
+    testonto.new_entity("UnderKlasse", testonto.Klasse)
+    assert testonto.UnderKlasse.prefLabel == ["UnderKlasse"]    
+
+    assert testonto.get_by_label_all("*") == {
+        testonto.prefLabel,
+        testonto.Class,
+        testonto.SpecialAnnotation,
+        testonto.Klasse,
+        testonto.UnderKlasse
+    }
     assert testonto.get_by_label_all("Class*") == {
         testonto.Class,
     }
+    
 
+    # Check that imported ontologies are searched
+    imported_onto = testonto.world.get_ontology(
+        repo_dir / "tests" / "testonto" / "testonto.ttl"
+    ).load()
+    testonto.imported_ontologies.append(imported_onto)
+    assert imported_onto.get_by_label("TestClass")
+    assert imported_onto.get_by_label("models:TestClass")
+
+    assert testonto.get_by_label("TestClass")
 
 def test_get_by_label_emmo(emmo: "Ontology") -> None:
     # Loading emmo-inferred where everything is sqashed into one ontology
@@ -86,28 +94,3 @@ def test_get_by_label_emmo(emmo: "Ontology") -> None:
 
     assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom
 
-
-import pytest
-
-from ontopy import get_ontology
-from ontopy.ontology import NoSuchLabelError
-
-
-# Loading emmo-inferred where everything is sqashed into one ontology
-emmo = get_ontology().load()
-assert emmo[emmo.Atom.name] == emmo.Atom
-assert emmo[emmo.Atom.iri] == emmo.Atom
-
-# Load an ontology with imported sub-ontologies
-onto = get_ontology(
-    "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
-).load()
-assert onto.Electrolyte.prefLabel.first() == "Electrolyte"
-
-
-# Check colon_in_name argument
-onto.Atom.altLabel.append("Element:X")
-with pytest.raises(NoSuchLabelError):
-    onto.get_by_label("Element:X")
-
-assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -82,6 +82,23 @@ def test_get_by_label_onto(repo_dir) -> None:
         testonto.Class,
     }
 
+    # Test with label annotations given directly when creating the ontology
+    testonto2 = get_ontology(
+        "http://domain_ontology/new_ontology",
+        label_annotations=[
+            "http://www.w3.org/2004/02/skos/core#prefLabel",
+            "http://www.w3.org/2004/02/skos/core#altLabel",
+        ],
+    )
+
+    testonto2.new_annotation_property(
+        "prefLabel",
+        parent=[owlready2.AnnotationProperty],
+    )
+    testonto2.new_entity("Class", owlready2.Thing, preflabel="Klasse")
+
+    assert testonto2.get_by_label("Klasse") == testonto2.Class
+
 
 def test_get_by_label_emmo(emmo: "Ontology") -> None:
     # Loading emmo-inferred where everything is sqashed into one ontology

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -15,6 +15,15 @@ def test_get_by_label_onto() -> None:
     assert testonto._label_annotations == None
     assert testonto.get_by_label("Class") == testonto.Class
 
+    imported_onto = world.get_ontology(
+        repo_dir / "tests" / "testonto" / "testonto.ttl"
+    ).load()
+    testonto.imported_ontologies.append(imported_onto)
+    assert imported_onto.get_by_label("TestClass")
+    assert imported_onto.get_by_label("models:TestClass")
+    testonto.set_default_label_annotations()
+    assert testonto.get_by_label("testclass")
+
 
 def test_get_by_label_all_onto() -> None:
     """Test that label annotations are added correctly if they are not added before

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -11,14 +11,14 @@ def test_get_by_label_onto(repo_dir) -> None:
     import owlready2
     from ontopy.ontology import DEFAULT_LABEL_ANNOTATIONS
 
-    # create ontology with one class and check that it is found 
+    # create ontology with one class and check that it is found
     testonto = get_ontology("http://domain_ontology/new_ontology")
     testonto.new_entity("Class", owlready2.Thing)
 
     assert testonto.label_annotations == DEFAULT_LABEL_ANNOTATIONS
     assert testonto.get_by_label("Class") == testonto.Class
     assert testonto.get_by_label_all("*") == {testonto.Class}
-    
+
     testonto.new_annotation_property(
         "SpecialAnnotation", owlready2.AnnotationProperty
     )
@@ -37,7 +37,8 @@ def test_get_by_label_onto(repo_dir) -> None:
 
     # Add prefLabel to ontology
     preflabel = testonto.new_annotation_property(
-       "prefLabel", parent=[owlready2.AnnotationProperty],
+        "prefLabel",
+        parent=[owlready2.AnnotationProperty],
     )
     preflabel.iri = "http://www.w3.org/2004/02/skos/core#prefLabel"
 
@@ -46,24 +47,23 @@ def test_get_by_label_onto(repo_dir) -> None:
         assert testonto.prefLabel.prefLabel == ["prefLabel"]
     testonto.prefLabel.prefLabel = "prefLabel"
     assert testonto.prefLabel.prefLabel == ["prefLabel"]
- 
+
     with pytest.raises(AssertionError):
         assert testonto.Klasse.prefLabel == ["Klasse"]
 
     testonto.new_entity("UnderKlasse", testonto.Klasse)
-    assert testonto.UnderKlasse.prefLabel == ["UnderKlasse"]    
+    assert testonto.UnderKlasse.prefLabel == ["UnderKlasse"]
 
     assert testonto.get_by_label_all("*") == {
         testonto.prefLabel,
         testonto.Class,
         testonto.SpecialAnnotation,
         testonto.Klasse,
-        testonto.UnderKlasse
+        testonto.UnderKlasse,
     }
     assert testonto.get_by_label_all("Class*") == {
         testonto.Class,
     }
-    
 
     # Check that imported ontologies are searched
     imported_onto = testonto.world.get_ontology(
@@ -74,6 +74,9 @@ def test_get_by_label_onto(repo_dir) -> None:
     assert imported_onto.get_by_label("models:TestClass")
 
     assert testonto.get_by_label("TestClass")
+
+    assert testonto.get_by_label_all("Clas*", exact_match=True) == {}
+
 
 def test_get_by_label_emmo(emmo: "Ontology") -> None:
     # Loading emmo-inferred where everything is sqashed into one ontology
@@ -93,4 +96,3 @@ def test_get_by_label_emmo(emmo: "Ontology") -> None:
         onto.get_by_label("Element:X")
 
     assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom
-

--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -75,7 +75,12 @@ def test_get_by_label_onto(repo_dir) -> None:
 
     assert testonto.get_by_label("TestClass")
 
-    assert testonto.get_by_label_all("Clas*", exact_match=True) == {}
+    # Check exact_match=True in get_by_label_all()
+    assert testonto.get_by_label_all("*", exact_match=True) == set()
+    assert testonto.get_by_label_all("Clas*", exact_match=True) == set()
+    assert testonto.get_by_label_all("Class", exact_match=True) == {
+        testonto.Class,
+    }
 
 
 def test_get_by_label_emmo(emmo: "Ontology") -> None:

--- a/tests/test_get_by_label_new.py
+++ b/tests/test_get_by_label_new.py
@@ -1,0 +1,125 @@
+import pytest
+
+from ontopy import get_ontology
+from ontopy.ontology import NoSuchLabelError
+
+
+def test_get_by_label_onto(repo_dir) -> None:
+    """Test that label annotations are added correctly if they are not added before
+    using get_by_label
+    """
+    import ontopy
+    import owlready2
+
+    world = ontopy.World()
+    testonto = world.get_ontology("http://domain_ontology/new_ontology")
+    testonto.new_entity("Class", owlready2.Thing)
+    assert testonto._label_annotations == None
+    assert testonto.get_by_label("Class") == testonto.Class
+
+    imported_onto = world.get_ontology(
+        repo_dir / "tests" / "testonto" / "testonto.ttl"
+    ).load()
+    testonto.imported_ontologies.append(imported_onto)
+    assert imported_onto.get_by_label("TestClass")
+    assert imported_onto.get_by_label("models:TestClass")
+    print("****classes in testonto, inlcuding imports*****")
+    print(list(testonto.classes(imported=True)))
+    print("------classes in imported_onto including imports----------")
+    print(list(imported_onto.classes(imported=True)))
+    print("------classes in imported_onto NOT including imports----------")
+    print(list(imported_onto.classes(imported="text")))
+    print("gfgdfsgsd")
+
+    assert testonto.get_by_label("TestClass")
+
+
+'''
+def test_get_by_label_all_onto() -> None:
+    """Test that label annotations are added correctly if they are not added before
+    using get_by_label_all
+    """
+    import owlready2
+    from utilities import setassert
+
+    testonto = get_ontology("http://domain_ontology/new_ontology")
+    testonto.new_entity("Class", owlready2.Thing)
+    assert testonto._label_annotations == None
+    assert testonto.get_by_label_all("*") == {testonto.Class}
+    testonto.new_annotation_property(
+        "SpecialAnnotation", owlready2.AnnotationProperty
+    )
+    testonto.Class.SpecialAnnotation.append("This is a comment")
+    testonto.set_default_label_annotations()
+
+    testonto.new_entity("Klasse", testonto.Class)
+
+    setassert(testonto.Klasse.prefLabel, ["Klasse"])
+
+    testonto.Klasse.altLabel = "Class2"
+    setassert(
+        testonto.get_by_label_all("*"),
+        {
+            testonto.prefLabel,
+            testonto.altLabel,
+            testonto.Class,
+            testonto.SpecialAnnotation,
+            testonto.Klasse,
+        },
+    )
+    setassert(
+        testonto.get_by_label_all("Class*"),
+        {
+            testonto.Class,
+            testonto.Klasse,
+        },
+    )
+
+
+
+
+def test_get_by_label_emmo(emmo: "Ontology") -> None:
+    # Loading emmo-inferred where everything is sqashed into one ontology
+    emmo = get_ontology().load()
+    assert emmo[emmo.Atom.name] == emmo.Atom
+    assert emmo[emmo.Atom.iri] == emmo.Atom
+
+    # Load an ontology with imported sub-ontologies
+    onto = get_ontology(
+        "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
+    ).load()
+    assert str(onto.Electrolyte.prefLabel.first()) == "Electrolyte"
+
+    # Check colon_in_name argument
+    onto.Atom.altLabel.append("Element:X")
+    with pytest.raises(NoSuchLabelError):
+        onto.get_by_label("Element:X")
+
+    assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom
+
+
+import pytest
+
+from ontopy import get_ontology
+from ontopy.ontology import NoSuchLabelError
+
+
+# Loading emmo-inferred where everything is sqashed into one ontology
+emmo = get_ontology().load()
+assert emmo[emmo.Atom.name] == emmo.Atom
+assert emmo[emmo.Atom.iri] == emmo.Atom
+
+# Load an ontology with imported sub-ontologies
+onto = get_ontology(
+    "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
+).load()
+assert str(onto.Electrolyte.prefLabel.first()) == "Electrolyte"
+
+
+# Check colon_in_name argument
+onto.Atom.altLabel.append("Element:X")
+with pytest.raises(NoSuchLabelError):
+    onto.get_by_label("Element:X")
+
+assert onto.get_by_label("Element:X", colon_in_label=True) == onto.Atom
+'''


### PR DESCRIPTION
# Description
get:by:label used to search wider than what ist was supposed to in the sense that is searched for prefLabels even when skos:prefLabel was not in the ontology.

Furthermore, documentation for get_by_label and get_by_label_all has been updated.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [x] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
