### PR TITLE
Skip checking dimensional units for domain ontologies that doesn't load this class.

### DIFF
--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -405,6 +405,11 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
 
     def test_dimensional_unit(self):
         """Check correct syntax of dimension string of dimensional units."""
+
+        # This test requires that the ontology has imported SIDimensionalUnit
+        if "SIDimensionalUnit" not in self.onto:
+            self.skipTest("SIDimensionalUnit is not imported")
+
         # pylint: disable=invalid-name
         regex = re.compile(
             "^T([+-][1-9][0-9]*|0) L([+-][1-9]|0) M([+-][1-9]|0) "

--- a/tests/test_emmocheck_module.py
+++ b/tests/test_emmocheck_module.py
@@ -4,6 +4,7 @@ from emmopy.emmocheck import main
 main(
     argv=[
         "--url-from-catalog",
+        "--check-imported",
         # Test against a specific commit of EMMO 1.0.0-beta5
         "https://raw.githubusercontent.com/emmo-repo/EMMO/3b93e2c9c45ab8d9882d2d6385276ff905095798/emmo.ttl",
     ]


### PR DESCRIPTION
# Description
Do not check SI dimensional units if the checked domain ontology does not load that class.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
