### PR TITLE
Updated the getattr patch

### DIFF
--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -29,6 +29,7 @@ owlready2.set_render_func(render_func)
 # Extending ThingClass (classes)
 # ==============================
 
+# Save a copy of the unpatched ThingClass.__getattr__() method.
 save_getattr = ThingClass.__getattr__
 
 
@@ -133,7 +134,13 @@ def _getattr(self, name):
             entity = self.namespace.ontology.get_by_label(name)
             # add annotation property to world._props for faster access later
             self.namespace.world._props[name] = entity
-            return save_getattr(self, entity.name)
+
+            # Try first unpatched getattr method to avoid risking
+            # infinite recursion.
+            try:
+                return save_getattr(self, entity.name)
+            except AttributeError:
+                return getattr(self, entity.name)
         raise err
 
 


### PR DESCRIPTION
# Description
Ensure that we can access annotations added by imported ontologies.

This issue was revealed when running the periodictable script for EMMO 1.0.0-beta5.

## Type of change
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
