### PR TITLE
Copy EMMO annotations

### DIFF
--- a/tests/testonto/domainonto.ttl
+++ b/tests/testonto/domainonto.ttl
@@ -36,7 +36,7 @@
     skos:prefLabel "hasDataProperty"@en .
 
 
-# Declare elucidation here since we are not importing EMMO
+# Declare emmo:elucidation and skos:prefLabel here since we are not importing these ontologies
 emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 a owl:AnnotationProperty ;
     skos:prefLabel "elucidation"@en ;
     rdfs:comment "Short enlightening explanation aimed to facilitate the user in drawing the connection (interpretation) between a OWL entity and the real world object(s) for which it stands."@en .

--- a/tests/testonto/domainonto.ttl
+++ b/tests/testonto/domainonto.ttl
@@ -1,0 +1,44 @@
+@prefix : <https://w3id.org/emmo/domain-onto#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix emmo: <https://www.w3.org/emmo#> .
+
+
+<https://w3id/org/emmo/domain-onto> rdf:type owl:Ontology ;
+    owl:versionIRI <https://w3id/org/emmo/domain-onto/0.1.0> ;
+    owl:versionInfo "0.1.0" ;
+    dcterms:abstract "Test for an EMMO-based domain ontolgoy."@en .
+
+
+:testclass rdf:type owl:Class ;
+    rdfs:subClassOf owl:Thing ;
+    skos:prefLabel "TestClass"@en ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A test class."@en .
+
+:testobjectproperty rdf:type owl:ObjectProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range :testclass ;
+    skos:prefLabel "hasObjectProperty"@en .
+
+:testannotationproperty rdf:type owl:AnnotationProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range rdfs:Literal ;
+    skos:prefLabel "hasAnnotationProperty"@en .
+
+:testdatatypeproperty rdf:type owl:DatatypeProperty ;
+    rdfs:domain :testclass ;
+    rdfs:range xsd:string ;
+    skos:prefLabel "hasDataProperty"@en .
+
+
+# Declare elucidation here since we are not importing EMMO
+emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 a owl:AnnotationProperty ;
+    skos:prefLabel "elucidation"@en ;
+    rdfs:comment "Short enlightening explanation aimed to facilitate the user in drawing the connection (interpretation) between a OWL entity and the real world object(s) for which it stands."@en .
+
+skos:prefLabel a owl:AnnotationProperty .

--- a/tests/testonto/domainonto.ttl
+++ b/tests/testonto/domainonto.ttl
@@ -36,9 +36,16 @@
     skos:prefLabel "hasDataProperty"@en .
 
 
-# Declare emmo:elucidation and skos:prefLabel here since we are not importing these ontologies
+# Declare skos:prefLabel, emmo:elucidation and emmo:definition here
+# since we are not importing these ontologies
 emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 a owl:AnnotationProperty ;
+    rdfs:subPropertyOf rdfs:comment ;
     skos:prefLabel "elucidation"@en ;
     rdfs:comment "Short enlightening explanation aimed to facilitate the user in drawing the connection (interpretation) between a OWL entity and the real world object(s) for which it stands."@en .
+
+:EMMO_70fe84ff_99b6_4206_a9fc_9a8931836d84 a owl:AnnotationProperty ;
+    rdfs:subPropertyOf rdfs:comment ;
+    skos:prefLabel "definition"@en ;
+    rdfs:comment "Precise and univocal description of an ontological entity in the framework of an axiomatic system."@en .
 
 skos:prefLabel a owl:AnnotationProperty .

--- a/tests/tools/test_ontoconvert.py
+++ b/tests/tools/test_ontoconvert.py
@@ -40,32 +40,38 @@ def test_run() -> None:
     assert re.search("<https://w3id.org/ex/testonto> .* owl:Ontology", output2)
     assert re.search("testclass .* owl:Class", output2)
 
-    # Test 3 - copy-annotation
+    # Test 3 - copy-emmo-annotations
+    infile3 = ontodir / "domainonto.ttl"
+    outfile3 = outdir / "test_ontoconvert3.ttl"
     ontoconvert.main(
         [
-            "-p",
+            "--copy-emmo-annotations",
             "--iri=https://w3id.org/ex/testonto",
             "--base-iri=https://w3id.org/ex/testonto#",
-            str(ontodir / "testonto.ttl"),
-            str(outdir / "test_ontoconvert3.ttl"),
+            str(infile3),
+            str(outfile3),
         ]
     )
-    input3 = (ontodir / "testonto.ttl").read_text()
-    output3 = (outdir / "test_ontoconvert3.ttl").read_text()
-    assert not re.search('rdfs:label "hasAnnotationProperty"@en', input3)
-    assert re.search('rdfs:label "hasAnnotationProperty"@en', output3)
+    input3 = infile3.read_text()
+    output3 = outfile3.read_text()
+    assert 'rdfs:label "hasAnnotationProperty"@en' not in input3
+    assert 'rdfs:label "hasAnnotationProperty"@en' in output3
+    assert 'rdfs:comment "A test class."@en' not in input3
+    assert 'rdfs:comment "A test class."@en' in output3
 
     # Test 4 - copy-annotation with source as annotation label
+    infile4 = ontodir / "testonto.ttl"
+    outfile4 = outdir / "test_ontoconvert3.ttl"
     ontoconvert.main(
         [
             "-c prefLabel-->http://www.w3.org/2004/02/skos/core#hiddenLabel",
             "--iri=https://w3id.org/ex/testonto",
             "--base-iri=https://w3id.org/ex/testonto#",
-            str(ontodir / "testonto.ttl"),
-            str(outdir / "test_ontoconvert4.ttl"),
+            str(infile4),
+            str(outfile4),
         ]
     )
-    input4 = (ontodir / "testonto.ttl").read_text()
-    output4 = (outdir / "test_ontoconvert4.ttl").read_text()
+    input4 = infile4.read_text()
+    output4 = outfile4.read_text()
     assert not re.search('skos:hiddenLabel "hasAnnotationProperty"@en', input4)
     assert re.search('skos:hiddenLabel "hasAnnotationProperty"@en', output4)

--- a/tools/ontoconvert
+++ b/tools/ontoconvert
@@ -83,8 +83,9 @@ def main(argv: list = None):
             "Alias for: `--copy-annotation="
             "http://www.w3.org/2004/02/skos/core#prefLabel"
             "-->http://www.w3.org/2000/01/rdf-schema#label "
-            "--copy-annotation="
-            "https://w3id.org/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9"
+            "--copy-annotation=elucidation"
+            "-->http://www.w3.org/2000/01/rdf-schema#comment`"
+            "--copy-annotation=definition"
             "-->http://www.w3.org/2000/01/rdf-schema#comment`"
         ),
     )
@@ -224,6 +225,7 @@ def main(argv: list = None):
                 "http://www.w3.org/2004/02/skos/core#prefLabel"
                 "-->http://www.w3.org/2000/01/rdf-schema#label",
                 "elucidation-->http://www.w3.org/2000/01/rdf-schema#comment",
+                "definition-->http://www.w3.org/2000/01/rdf-schema#comment",
             ]
         )
 

--- a/tools/ontoconvert
+++ b/tools/ontoconvert
@@ -223,9 +223,7 @@ def main(argv: list = None):
             [
                 "http://www.w3.org/2004/02/skos/core#prefLabel"
                 "-->http://www.w3.org/2000/01/rdf-schema#label",
-                "https://w3id.org/emmo#"
-                "EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9"
-                "-->http://www.w3.org/2000/01/rdf-schema#comment",
+                "elucidation-->http://www.w3.org/2000/01/rdf-schema#comment",
             ]
         )
 

--- a/tools/ontoconvert
+++ b/tools/ontoconvert
@@ -74,12 +74,18 @@ def main(argv: list = None):
         ),
     )
     parser.add_argument(
-        "--copy-preflabel",
-        "-p",
+        "--copy-emmo-annotations",
+        "-e",
         action="store_true",
         help=(
-            "Alias for: `--copy-annotation=http://www.w3.org/2004/02/skos/"
-            "core#prefLabel-->http://www.w3.org/2000/01/rdf-schema#label`"
+            "Make a copy of EMMO annotations to plain RDFS for increased "
+            "interoperability. "
+            "Alias for: `--copy-annotation="
+            "http://www.w3.org/2004/02/skos/core#prefLabel"
+            "-->http://www.w3.org/2000/01/rdf-schema#label "
+            "--copy-annotation="
+            "https://w3id.org/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9"
+            "-->http://www.w3.org/2000/01/rdf-schema#comment`"
         ),
     )
     parser.add_argument(
@@ -211,12 +217,16 @@ def main(argv: list = None):
     if not output_format:
         output_format = "xml"
 
-    if args.copy_annotation is None:
-        args.copy_annotation = []
-    if args.copy_preflabel:
-        args.copy_annotation.append(
-            "http://www.w3.org/2004/02/skos/core#prefLabel-->"
-            "http://www.w3.org/2000/01/rdf-schema#label"
+    # Annotations to copy with --copy-emmo-annotations
+    if args.copy_emmo_annotations:
+        args.copy_annotation.extend(
+            [
+                "http://www.w3.org/2004/02/skos/core#prefLabel"
+                "-->http://www.w3.org/2000/01/rdf-schema#label",
+                "https://w3id.org/emmo#"
+                "EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9"
+                "-->http://www.w3.org/2000/01/rdf-schema#comment",
+            ]
         )
 
     # Perform conversion


### PR DESCRIPTION
# Description
Renamed option `--copy-preflabel` to `--copy-emmo-annotations` and more content to what it alias.

The intention with this option is to make it easy to publish EMMO-based ontologies that are understood by standard tools (including FOOPS).

## Type of change
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
