### PR TITLE
Load doamin-battery instead of battinfo which is just an extra wrapping

### DIFF
--- a/tests/test_get_by_label.py
+++ b/tests/test_get_by_label.py
@@ -109,8 +109,11 @@ def test_get_by_label_emmo(emmo: "Ontology") -> None:
     assert emmo[emmo.Atom.iri] == emmo.Atom
 
     # Load an ontology with imported sub-ontologies
+    # Note that this test also includes testing of loading
+    # ontology with catalog file directly from the web
+    # It is therefore not duplicated in test_load.
     onto = get_ontology(
-        "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl"
+        "https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl"
     ).load()
     assert onto.Electrolyte.prefLabel.en.first() == "Electrolyte"
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -35,11 +35,8 @@ def test_load(repo_dir: "Path", testonto: "Ontology") -> None:
     assert str(testonto.TestClass.prefLabel.first()) == "TestClass"
 
     # Use catalog file when downloading from web
-    onto = get_ontology(
-        "https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/"
-        "battinfo.ttl"
-    ).load()
-    assert str(onto.Electrolyte.prefLabel.first()) == "Electrolyte"
+    # This is tested in test_get_by_label in which some additional tests
+    # are performed on labels.
 
     with pytest.raises(
         EMMOntoPyException,


### PR DESCRIPTION
# Description
This should deprecate PR #741 in which the tests where removed, also incorrectly.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
