### PR TITLE
Added release_pat secret to ci_cd_updated_master workflow

### DIFF
--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -29,3 +29,5 @@ jobs:
         (LICENSE.txt),(LICENSE.md)
         (tools),(../tools)
       changelog_exclude_labels: dependencies
+    secrets:
+      PAT: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
# Description
Release pat was not added to the workflow for ci_cd when updating master, and as a consequence the
depandabot-updates branch could not be updated.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
