### PR TITLE
Updated to owlready2==0.44

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ defusedxml>=0.7.1,<1
 graphviz>=0.16,<0.21
 numpy>=1.19.5,<3
 openpyxl>=3.0.9,<3.2
-Owlready2>=0.28,!=0.32,!=0.34,<0.44
+Owlready2>=0.28,!=0.32,!=0.34,<0.45
 packaging>=21.0,<25
 pandas>=1.2,<2.3
 Pygments>=2.7.4,<3


### PR DESCRIPTION
# Description
Upgrades of owlready has been halted for a while due to breaking changes.
This is due to a change introduced in owlready2==0.45 (adding python names to classes in the ontology), 
and the automatic update to supporting owlready2==0.44 should not have been stopped. 


## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
