### PR TITLE
Corrected test when loading rdfs. It used type for is_a. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ defusedxml>=0.7.1,<1
 graphviz>=0.16,<0.21
 numpy>=1.19.5,<3
 openpyxl>=3.0.9,<3.2
-Owlready2>=0.28,!=0.32,!=0.34,<0.46
+Owlready2>=0.28,!=0.32,!=0.34,<0.47
 packaging>=21.0,<25
 pandas>=1.2,<2.3
 Pygments>=2.7.4,<3

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -55,9 +55,9 @@ def test_load(repo_dir: "Path", testonto: "Ontology") -> None:
 
 
 def test_load_rdfs() -> None:
+    """Test to load non-emmo based ontologies rdf and rdfs"""
     from ontopy import get_ontology
 
-    # Test loading non-EMMO-based ontologies rdf and rdfs
     rdf_onto = get_ontology(
         "https://www.w3.org/1999/02/22-rdf-syntax-ns.ttl"
     ).load(emmo_based=False)
@@ -65,4 +65,4 @@ def test_load_rdfs() -> None:
         emmo_based=False
     )
     rdfs_onto.Class  # Needed to initialize rdfs_onto
-    assert type(rdf_onto.HTML).iri == rdfs_onto.Datatype.iri
+    assert rdf_onto.HTML.is_a[0].iri == rdfs_onto.Datatype.iri


### PR DESCRIPTION
# Description
A bugfix in 0wlready2==0.46 corrected reutning what is returned when using type on dataclasses.
We had used type instead of is_a in the test and this has now been corrected.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
