### PR TITLE
Emmocheck now does not check prefLabel for any of entities specific prefixes

### DIFF
--- a/emmopy/emmocheck.py
+++ b/emmopy/emmocheck.py
@@ -89,34 +89,7 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
         The only allowed exception is entities who's representation
         starts with "owl.".
         """
-        exceptions = set(
-            (
-                "0.1.homepage",  # foaf:homepage
-                "0.1.logo",
-                "0.1.page",
-                "0.1.name",
-                "bibo:doi",
-                "core.altLabel",
-                "core.hiddenLabel",
-                "core.prefLabel",
-                "terms.abstract",
-                "terms.alternative",
-                "terms:bibliographicCitation",
-                "terms.contributor",
-                "terms.created",
-                "terms.creator",
-                "terms.hasFormat",
-                "terms.identifier",
-                "terms.issued",
-                "terms.license",
-                "terms.modified",
-                "terms.publisher",
-                "terms.source",
-                "terms.title",
-                "vann:preferredNamespacePrefix",
-                "vann:preferredNamespaceUri",
-            )
-        )
+        exceptions = set()
         exceptions.update(
             self.get_config("test_number_of_labels.exceptions", ())
         )
@@ -125,15 +98,29 @@ class TestSyntacticEMMOConventions(TestEMMOConventions):
             in self.onto.world._props  # pylint: disable=protected-access
         ):
             for entity in self.onto.classes(self.check_imported):
-                if repr(entity) not in exceptions:
-                    with self.subTest(
-                        entity=entity,
-                        label=get_label(entity),
-                        prefLabels=entity.prefLabel,
-                    ):
-                        if not repr(entity).startswith("owl."):
-                            self.assertTrue(hasattr(entity, "prefLabel"))
-                            self.assertEqual(1, len(entity.prefLabel))
+                # Skip concepts from exceptions and common w3c vocabularies
+                vocabs = (
+                    "owl.",
+                    "0.1.",
+                    "bibo.",
+                    "core.",
+                    "terms.",
+                    "vann.",
+                    "schema.org",
+                )
+                r = repr(entity)
+                if r in exceptions or any(r.startswith(v) for v in vocabs):
+                    continue
+
+                #    if repr(entity) not in exceptions:
+                with self.subTest(
+                    entity=entity,
+                    label=get_label(entity),
+                    prefLabels=entity.prefLabel,
+                ):
+                    if not repr(entity).startswith("owl."):
+                        self.assertTrue(hasattr(entity, "prefLabel"))
+                        self.assertEqual(1, len(entity.prefLabel))
         else:
             self.fail("ontology has no prefLabel")
 
@@ -233,7 +220,15 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
         for entity in self.onto.classes(self.check_imported):
 
             # Skip concepts from exceptions and common w3c vocabularies
-            vocabs = "owl.", "0.1.", "bibo.", "core.", "terms.", "vann."
+            vocabs = (
+                "owl.",
+                "0.1.",
+                "bibo.",
+                "core.",
+                "terms.",
+                "vann.",
+                "shchema.org",
+            )
             r = repr(entity)
             if r in exceptions or any(r.startswith(v) for v in vocabs):
                 continue

--- a/tests/ontopy_tests/test_prefix.py
+++ b/tests/ontopy_tests/test_prefix.py
@@ -11,7 +11,7 @@ def test_prefix(testonto: "Ontology", emmo: "Ontology") -> None:
     """Test prefix in ontology"""
 
     print(testonto.get_by_label_all("*"))
-    assert len(testonto.get_by_label_all("*")) == 14
+    assert len(testonto.get_by_label_all("*")) == 15
     assert set(testonto.get_by_label_all("*", prefix="testonto")) == set(
         [
             testonto.alternative,

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -24,10 +24,12 @@ def test_classes(repo_dir) -> None:
         testonto.TestClass,
         testonto.get_by_label("models:TestClass"),
         testonto.Class,
+        testonto.Organization,
     }
     assert set(imported_onto.classes(imported=True)) == {
         imported_onto.TestClass,
         imported_onto.get_by_label("models:TestClass"),
+        testonto.Organization,
     }
     assert set(imported_onto.classes(imported=False)) == {
         imported_onto.TestClass

--- a/tests/testonto/models.ttl
+++ b/tests/testonto/models.ttl
@@ -5,6 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <https://schema.org/> .
 @base <http://emmo.info/models> .
 
 <http://emmo.info/models> rdf:type owl:Ontology ;
@@ -14,6 +15,13 @@
 # Annotations
 skos:prefLabel rdf:type owl:AnnotationProperty .
 skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+# Classes
+
+###  https://schema.org/Organization
+schema:Organization rdf:type owl:Class .
+
 
 
 :testclass rdf:type owl:Class ;

--- a/tests/tools/test_emmocheck.py
+++ b/tests/tools/test_emmocheck.py
@@ -18,6 +18,11 @@ def test_run() -> None:
     # The main() method will raise an exception on error, so it is
     # sufficient to just call it here
 
-    emmocheck.main(["--skip=test_description", str(test_file)])
+    status = emmocheck.main(["--skip=test_description", str(test_file)])
+    assert status == 0
 
-    emmocheck.main([str(test_file)])
+    # This will fail because the ontology does not contain
+    # the emmo.properties elucidation, description
+    # or conceptualisation.
+    status = emmocheck.main([str(test_file)])
+    assert status == 1


### PR DESCRIPTION
prefixed ommitted "owl.", "0.1.", "bibo.", "core.",  "terms.", "vann.", "schema.org",

Also corrected the emmocheck to fail if status returned is not 0.

NB! We do not only check emmo-terms, because it should be possible to make emmo-compliant ontologies that do not start with w3id.org/emmo.

# Description
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [x] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
