### PR TITLE
move from sintef/ci-cd safety to safety own setup

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -28,20 +28,7 @@ jobs:
 
 
       # safety-specific settings
-      run_safety: true
-      # 48547: RDFLib vulnerability: https://pyup.io/vulnerabilities/PVE-2022-48547/48547/
-      # 44715-44717: NumPy vulnerabilities:
-      #  https://pyup.io/vulnerabilities/CVE-2021-41495/44715/
-      #  https://pyup.io/vulnerabilities/CVE-2021-41496/44716/
-      #  https://pyup.io/vulnerabilities/CVE-2021-34141/44717/
-      # 70612: Jinja2 vulnerability. Only used as subdependency for mkdocs++ in tripper.
-      #  https://data.safetycli.com/v/70612/97c/
-      safety_options: |
-        --ignore=48547
-        --ignore=44715
-        --ignore=44716
-        --ignore=44717
-        --ignore=70612
+      run_safety: false
 
       # Build distribution
       run_build_package: true
@@ -61,6 +48,17 @@ jobs:
       landing_page_replacements: |
         (LICENSE.txt),(LICENSE.md)
         (tools),(../tools)
+
+
+  safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Run Safety CLI to check for vulnerabilities
+        uses: pyupio/safety-action@v1
+        with:
+          api-key: ${{ secrets.SAFETY_API_KEY }}
+          args: --detailed-output # To always see detailed output from this action
 
 
   pytest:

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -43,6 +43,7 @@ def test_get_by_label_onto(emmo: "Ontology") -> None:
             "workplaceHomepage",
             "name",
             "hasFormat",
+            "OWL2DLRestrictedAxiom",
             "OWLDLRestrictedAxiom",
             "preferredNamespaceUri",
             "uneceCommonCode",

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -22,7 +22,7 @@ def test_get_by_label_onto(emmo: "Ontology") -> None:
         "altLabel",
         "elucidation",
         "comment",
-        "label",
+        # "label",
     }
 
     annot = set(str(a) for a in emmo.Atom.get_annotations(all=True).keys())

--- a/tests/ontopy_tests/test_patch.py
+++ b/tests/ontopy_tests/test_patch.py
@@ -43,7 +43,7 @@ def test_get_by_label_onto(emmo: "Ontology") -> None:
             "workplaceHomepage",
             "name",
             "hasFormat",
-            "OWL2DLRestrictedAxiom",
+            "OWLDLRestrictedAxiom",
             "preferredNamespaceUri",
             "uneceCommonCode",
             "creator",
@@ -75,6 +75,8 @@ def test_get_by_label_onto(emmo: "Ontology") -> None:
             "status",
             "prefLabel",
             "ISO80000Reference",
+            "ISO9000Reference",
+            "ISO14040Reference",
             "unitSymbol",
             "qudtReference",
             "abstract",
@@ -84,6 +86,7 @@ def test_get_by_label_onto(emmo: "Ontology") -> None:
             "wikipediaReference",
             "title",
             "VIMTerm",
+            "figure",
         },
     )
 


### PR DESCRIPTION
# Description
safety has changed and sintef/ci-cd is deprecating support for it in favour of using safety actions directly.

In addition some changes in tests to reflect new release of emmo

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
