### PR TITLE
Handle timeout errors in redirectioncheck

### DIFF
--- a/tools/redirectioncheck
+++ b/tools/redirectioncheck
@@ -52,12 +52,20 @@ def test_redirection(url, redirected_url, conf=None):
     Returns:
         ok: Whether the redirection was successful.
     """
-    verbose = conf.get("verbose")
-    r = requests.get(url, timeout=5)
-    ok, reason, got = r.ok, r.reason, None
+    if conf is None:
+        conf = {}
+    verbose = int(conf["verbose"]) if "verbose" in conf else 1
+    timeout = float(conf["timeout"]) if "timeout" in conf else None
 
-    if r.ok and r.url != redirected_url:
-        ok, reason, got = False, "Invalid redirection", r.url
+    try:
+        r = requests.get(url, timeout=timeout)
+    except requests.Timeout:
+        ok, reason, got = False, "timeout", None
+    else:
+        if r.ok and r.url != redirected_url:
+            ok, reason, got = False, "Invalid redirection", r.url
+        else:
+            ok, reason, got = r.ok, r.reason, None
 
     if verbose:
         print(f"{url:64} {reason}")
@@ -92,10 +100,16 @@ def main(argv: list = None):
         action="store_const",
         const=0,
         dest="verbose",
-        help="Whether to be silent..",
+        help="Whether to be silent.",
+    )
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        default="3",
+        help="Number of seconds before timing out. Defaults to 3.",
     )
     args = parser.parse_args(args=argv)
-    conf = {"verbose": args.verbose}
+    conf = {"verbose": args.verbose, "timeout": args.timeout}
 
     return test_all(args.yamlfile, conf=conf)
 


### PR DESCRIPTION
# Description
Instead of an unreadable traceback, report timeout as a standard failure.

**Question**: Should timeout be reported as success instead? 
If the request times out, it normally means that the redirection service is currently down, not that there necessary is something wrong with the redirections.
