### PR TITLE
Added `--namespace` option to `ontoconvert`

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -887,6 +887,7 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
         overwrite=False,
         recursive=False,
         squash=False,
+        namespaces=None,
         write_catalog_file=False,
         append_catalog=False,
         catalog_file="catalog-v001.xml",
@@ -920,6 +921,9 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
             If true, rdflib will be used to save the current ontology
             together with all its sub-ontologies into `filename`.
             It makes no sense to combine this with `recursive`.
+        namespaces: dict
+            Dict mapping prefixes to additional namespaces. Only used when
+            saving to turtle.
         write_catalog_file: bool
             Whether to also write a catalog file to disk.
         append_catalog: bool
@@ -1032,12 +1036,13 @@ class Ontology(owlready2.Ontology):  # pylint: disable=too-many-public-methods
                 graph.add(triple)
 
             # Add common namespaces unknown to rdflib
-            extra_namespaces = [
-                ("", self.base_iri),
-                ("swrl", "http://www.w3.org/2003/11/swrl#"),
-                ("bibo", "http://purl.org/ontology/bibo/"),
-            ]
-            for prefix, iri in extra_namespaces:
+            if namespaces is None:
+                namespaces = {}
+            namespaces.setdefault("", self.base_iri)
+            namespaces.setdefault("locn", "http://www.w3.org/ns/locn#")
+            namespaces.setdefault("swrl", "http://www.w3.org/2003/11/swrl#")
+            namespaces.setdefault("bibo", "http://purl.org/ontology/bibo/")
+            for prefix, iri in namespaces.items():
                 graph.namespace_manager.bind(
                     prefix, rdflib.Namespace(iri), override=False
                 )

--- a/tools/ontoconvert
+++ b/tools/ontoconvert
@@ -94,8 +94,19 @@ def main(argv: list = None):
         ),
     )
     parser.add_argument(
-        "--no-catalog",
+        "--namespace",
         "-n",
+        action="append",
+        default=[],
+        metavar="PREFIX:NAMESPACE",
+        help=(
+            "Additional prefix, namespace pairs to add to the header of turtle "
+            "output."
+        ),
+    )
+    parser.add_argument(
+        "--no-catalog",
+        "-N",
         action="store_false",
         dest="url_from_catalog",
         default=None,
@@ -291,6 +302,7 @@ def main(argv: list = None):
             overwrite=args.overwrite,
             recursive=args.recursive,
             squash=args.squash,
+            namespaces=dict(args.namespace),
             write_catalog_file=bool(args.catalog_file),
             append_catalog=args.append_catalog,
             catalog_file=args.catalog_file,


### PR DESCRIPTION
# Description
Added a `--namespace` option to `ontoconvert`. This lets the user specify namespace prefixes in turtle output instead of the default `ns1`, `ns2`, ...


## Type of change
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
